### PR TITLE
CAS 2.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/History.md
+++ b/History.md
@@ -1,17 +1,17 @@
 
-0.0.4 / 2012-02-07
+0.0.4 / 2012-02-17
 ==================
 
   * Support for CAS 2.0 features
       - CAS extended attributes
       - CAS proxies
       
-        . using built-in PGT callback and proxy servers
-        . can make proxied requests with proxiedRequest()
-        
-        . can authenticate using external proxy server
+        . provides built-in PGT callback and proxy servers
+        . can make proxied requests with internal proxy server
         . can act as a standalone external proxy server for others
+        . can make proxied requests with external proxy server
         
+  * single sign out support
   * auto redirect with authenticate()
   * logout
 

--- a/History.md
+++ b/History.md
@@ -1,9 +1,17 @@
 
-0.0.4 / 2012-01-18
+0.0.4 / 2012-02-07
 ==================
 
-  * Support for basic CAS 2.0 features
-  * CAS attributes
+  * Support for CAS 2.0 features
+      - CAS extended attributes
+      - CAS proxies
+      
+        . using built-in PGT callback and proxy servers
+        . can make proxied requests with proxiedRequest()
+        
+        . can authenticate using external proxy server
+        . can act as a standalone external proxy server for others
+        
   * auto redirect with authenticate()
   * logout
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,27 @@
+0.0.5 / 2015-09-04
+==================
+
+  * Functionality unchanged, but terminology has been revised for correctness and clarity.
+      * Disambiguate `PGT callback server` from `proxy server`
+      * Disambiguate `CAS proxy` from `HTTP proxy`
+      - HTTP proxy functionality unchanged but is now **deprecated**
+        - Originally, the HTTP proxy functions were intended to be the way of making authorized requests from 3rd party services. However, it is better to simply obtain a `ticket` via getProxyTicket() to use with a fully featured HTTP client like [request](https://github.com/request/request).
+
+  * Some options have been renamed (old names are **deprecated** but still work):
+      * old: `proxy_server` => new: `pgt_server`
+      * old: `proxy_callback_host` => new: `pgt_host`
+      * old: `proxy_callback_port` => new: `pgt_port`
+      * old: `proxy_server_key` => new: `ssl_key`
+      * old: `proxy_server_cert` => new: `ssl_cert`
+      * old: `proxy_server_ca` => new: `ssl_ca`
+
+  * These options are **deprecated** (but work the same as before):
+      - `proxy_server_port`
+      - `external_proxy_url`
+    
+  * These methods are also **deprecated** (but work the same as before):
+      - proxiedRequest()
+      - proxiedRequestExternal()
 
 0.0.4 / 2012-02-17
 ==================

--- a/History.md
+++ b/History.md
@@ -1,4 +1,13 @@
 
+0.0.4 / 2012-01-18
+==================
+
+  * Support for basic CAS 2.0 features
+  * CAS attributes
+  * auto redirect with authenticate()
+  * logout
+
+
 0.0.1 / 2010-01-03
 ==================
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # cas
 
   Central Authentication Service (CAS) client for Node.js
@@ -23,15 +22,18 @@ via npm:
 
 Setup:
 
+```javascript
     var CAS = require('cas');
     var cas = new CAS({
         base_url: 'https://cas.uwaterloo.ca/cas', 
         service: 'my_service',
         version: 2.0
     });
+```
 
 Using it in a login route:
 
+```javascript
     exports.cas_login = function(req, res) {
       var ticket = req.param('ticket');
       if (ticket) {
@@ -48,9 +50,11 @@ Using it in a login route:
         res.redirect('/');
       }
     };
+```
 
 Using the auto redirect authentication:
 
+```javascript
     exports.cas_login = function(req, res) {
       cas.authenticate(req, res, function(err, status, username, extended) {
         if (err) {
@@ -62,9 +66,11 @@ Using the auto redirect authentication:
         }
       });    
     }
+```
 
-Longer example with CAS proxy:
+Longer example with CAS proxy (also see the [wiki](https://github.com/joshchan/node-cas/wiki/CAS-Proxy)):
 
+```javascript
     var fs = require('fs');
     var http = require('http');
 
@@ -151,6 +157,7 @@ Longer example with CAS proxy:
         
     });
     server.listen(8080);
+```
 
 ## License 
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,9 +3,11 @@
 
   Central Authentication Service (CAS) client for Node.js
 
-  This module only handles the ticket validation step of the CAS login process. Planned features include functions to generate the login/logout URLs.
+  This module only handles the ticket validation step of the CAS login process, as well as functions for transparently authenticating or redirecting as needed. CAS attributes are also supported. Planned features include support for CAS proxy tickets and single sign-out.
 
-  Generally, to start the login process, send your users to: `https://cas_base_url/login?service=url_to_handle_ticket_validation`. In the University of Waterloo example below, this url would be: `https://cas.uwaterloo.ca/cas/login?service='my_service'`.
+  To start the login process manually, send your users to: `https://cas_base_url/login?service=url_to_handle_ticket_validation`. In the University of Waterloo example below, this url would be: `https://cas.uwaterloo.ca/cas/login?service='my_service'`.
+  
+  Or if you are using standard HTTP req/res objects for a web page, you may use the provided `authenticate()` function to handle the redirection automatically.
 
 ## Installation
 
@@ -18,7 +20,11 @@ via npm:
 Setup:
 
     var CAS = require('cas');
-    var cas = new CAS({base_url: 'https://cas.uwaterloo.ca/cas', service: 'my_service'});
+    var cas = new CAS({
+        base_url: 'https://cas.uwaterloo.ca/cas', 
+        service: 'my_service',
+        version: 2.0
+    });
 
 Using it in a login route:
 
@@ -38,6 +44,20 @@ Using it in a login route:
         res.redirect('/');
       }
     };
+
+Using the auto redirect authentication:
+
+    exports.cas_login = function(req, res) {
+      cas.authenticate(req, res, function(err, status, username, attributes) {
+        if (err) {
+          // Handle the error
+          res.send({error: err});
+        } else {
+          // Log the user in
+          res.send({status: status, username: username, attributes: attributes});
+        }
+      });    
+    }
 
 ## License 
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
   Central Authentication Service (CAS) client for Node.js
 
-  This module handles CAS authentication (with support for proxies and extended attributes), and can also transparently redirect a web page if needed. The ticket validation step is available as its own function for those who wish to handle things manually. Proxied requests can be made through a function call, or optionally through an HTTP request with custom headers. Planned features include support for single sign-out.
+  This module handles CAS authentication (with support for proxies and extended attributes), and can also transparently redirect a web page if needed. The ticket validation step is available as its own function for those who wish to handle things manually. Proxied requests can be made through a function call, or optionally through an HTTP request with custom headers. Single sign out is also supported with Express/Connect.
   
   To start the login process manually, send your users to: `https://cas_base_url/login?service=url_to_handle_ticket_validation`. In the University of Waterloo example below, this url would be: `https://cas.uwaterloo.ca/cas/login?service='my_service'`.
   

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -3,6 +3,9 @@
  * node-cas
  * Copyright(c) 2011 Casey Banner <kcbanner@gmail.com>
  * MIT Licensed
+ *
+ * A Node.js CAS client, implementing the protocol as defined at:
+ * http://www.jasig.org/cas/protocol
  */
 
 /**
@@ -31,28 +34,34 @@ var jsdom = require('jsdom');
  *       'external_pgt_url': 
  *           (optional) The URL of the external proxy's PGT callback.
  *           e.g. https://proxy.example.com:8989/
+ *           The CAS server will try to contact this host every time a user 
+ *           logs in. 
  *           Do not use with the `proxy_server` option.
  *       'external_proxy_url':
  *           (optional) The URL of the external CAS proxy. The protocol, 
  *           hostname, and port number are required. The path will be ignored.
  *           e.g. https://proxy.example.com:8080/
  *           Should be used together with the `external_pgt_url` option.
+ *           The CAS client will use this URL to make proxied requests.
  *
  *       'proxy_server': 
  *           (optional) Set to TRUE if you want to automatically start 
  *           a proxy callback server internally.
  *           Do not use with `external_pgt_url`.
+ *           The CAS client will use this internal server to make proxied 
+ *           requests.
  *       'proxy_server_port':
  *           (optional) The port to listen on for external proxy requests for 
  *           a CAS enabled service.
  *           Disabled by default.
  *       'proxy_callback_host':
  *           The publicly accessible host name of your callback server.
- *           It must be usable by the CAS server.
+ *           It must be usable by the CAS server. The CAS server will try to
+ *           contact this host every time a user logs in.
  *           Required only if you used `proxy_server`.
  *       'proxy_callback_port':
  *           (optional) The port to listen on for incoming connections from
- *           the CAS server. Default is 80443.
+ *           the CAS server. Used with `proxy_callback_host`. Default is 80443.
  *       'proxy_server_key':
  *           A string value of your SSL private key. 
  *           Required only if you used `proxy_server`.
@@ -61,8 +70,9 @@ var jsdom = require('jsdom');
  *           Required only if you used `proxy_server`.
  *
  *       'sso_servers':
- *           An array of IP addresses of servers that are allowed to make
- *           single sign out requests. Default is to accept all valid requests.
+ *           An array of IP addresses of servers that we will accept
+ *           single sign out requests from. Default is to accept all
+ *           well-formed requests no matter where they are from.
  *           Only relevant if you use handleSignleSignout().
  *     }
  * @api public
@@ -121,8 +131,8 @@ var CAS = module.exports = function CAS(options)
       }
       this.external_proxy_url = url.format(proxy_url);
     }
-    
   }
+
   // User is requesting the internal proxy server
   else if (options.proxy_server) {
     //// Required
@@ -170,6 +180,7 @@ CAS.version = '0.0.4';
  *      (optional) The URL of the service/page that is requesting 
  *      authentication. Default is to extract this automatically from
  *      the `req` object.
+ * @api public
  */
 CAS.prototype.authenticate = function(req, res, callback, service)
 {
@@ -227,13 +238,14 @@ CAS.prototype.authenticate = function(req, res, callback, service)
  * request. It is not compatible with basic node.js http req objects.
  *
  * @param {Object} req
- *      Express/Connect http serverRequest
+ *      Express/Connect HTTP serverRequest.
  * @param {Object} res
- *      http serverResponse
+ *      HTTP serverResponse.
  * @param {Function} next
         Normal callback if no logout request was made.
  * @param {Function} logoutCallback
  *      function(ticket)
+ * @api public
  */
 CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
 {
@@ -252,9 +264,7 @@ CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
                     // This is the ticket that was issued by CAS when the user
                     // first logged in. Pass it into the callback so the
                     // framework can use it to delete the user's session.
-                    var ticket = ticketElem.textContent
-                        .replace(/^\s+/, '')
-                        .replace(/\s+$/, '');
+                    var ticket = ticketElem.textContent.trim();
                     return logoutCallback(ticket);
                 }
             }
@@ -284,6 +294,7 @@ CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
  *     (optional) Set this to TRUE to have the CAS server redirect the user 
  *      automatically. Default is for the CAS server to only provide a 
  *      hyperlink to be clicked on.
+ * @api public
  */
 CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
 {
@@ -447,11 +458,7 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
                 var proxies = [];
                 var elemProxies = elemSuccess.getElementsByTagName('cas:proxies');
                 for (var i=0; i<elemProxies.length; i++) {
-                    var thisProxy = elemProxies[i].textContent;
-                    // trim whitespace
-                    thisProxy = thisProxy
-                        .replace(/^\s+/, '')
-                        .replace(/\s+$/, '');
+                    var thisProxy = elemProxies[i].textContent.trim();
                     proxies.push(thisProxy);
                 }
 
@@ -574,18 +581,19 @@ CAS.prototype.getProxyTicket = function(pgt, targetService, callback)
  * For this to work, the local machine and the CAS server must be able to 
  * access each other on the network.
  *
- * @param {string/buffer} key
+ * @param {String/Buffer} key
  *    The SSL private key
- * @param {string/buffer} cert
+ * @param {String/Buffer} cert
  *    The SSL certificate
- * @param {string} callbackHost
+ * @param {String} callbackHost
  *    The publicly accessible hostname for the callback server.
- * @param {int} callbackPort
+ * @param {Integer} callbackPort
  *    The port number to listen on for incoming CAS PGT messages.
- * @param {int} proxyPort
+ * @param {Integer} proxyPort
  *    The port number to listen on for outgoing proxied requests.
  *    Omit this to disable the proxy server and only allow
  *    internal requests via CAS.proxiedRequest().
+ * @api public
  */
 CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort, proxyPort) 
 {
@@ -596,7 +604,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     var self = this;
     
     // This is the pgtURL that will be sent to the CAS server during a
-    // validation request.
+    // validation request. The CAS server will try to conntect to it.
     this.pgt_url = 'https://' + callbackHost + ':' + callbackPort + '/';
     
     // PGT callback server that listens for incoming connections from
@@ -604,6 +612,8 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     var pgtServer = https.createServer(serverOptions);
     console.log('Starting PGT callback server on port ' + callbackPort);
     pgtServer.addListener("request", function(req, res) {
+        // The incoming connection tells us what the PGTIOU and PGT values
+        // are. It expects only a HTTP 200 response in return.
         res.writeHead(200, {'Content-Type': 'text/plain'});
         res.end();
         // Save the PGT ticket into the memory store
@@ -611,10 +621,28 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
         var pgtIOU = reqURL.query['pgtIou'];
         var pgtID = reqURL.query['pgtId'];
         if (pgtIOU && pgtID) {
-            self.pgtStore[ pgtIOU ] = pgtID;
+            self.pgtStore[ pgtIOU ] = {
+                'pgtID': pgtID,
+                'time': process.uptime()
+            };
         }
     });
     pgtServer.listen(callbackPort);
+    
+    // Start an interval for PGT garbage collection.
+    if (this.pgtInterval) {
+        clearInterval(this.pgtInterval);
+    }
+    this.pgtInterval = setInterval(function() {
+        var now = process.uptime();
+        // Delete entries older than an hour
+        for (var pgtIOU in self.pgtStore) {
+            var timestamp = self.pgtStore[pgtIOU]['time'];
+            if (now - timestamp > 60 * 60 * 1) {
+                delete self.pgtStore[pgtIOU];
+            }
+        }
+    }, 1000 * 60);
     
     // Proxy server that listens for local connections and forwards them to 
     // the target service. Disabled by default.
@@ -699,8 +727,9 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
  * @param {Object} options
  *     Same as the options passed in to http.request(). This is where you 
  *     specify the service URL you are requesting.
- * @param {function} callback
+ * @param {Function} callback
  *     callback(err, req, res)
+ * @api public
  */
 CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) 
 {
@@ -710,10 +739,11 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
     }
 
     // Look up the PGT using the PGTIOU
-    var pgt = this.pgtStore[pgtIOU];
-    if (!pgt) {
+    if (!this.pgtStore[pgtIOU]) {
         callback(new Error('Invalid PGTIOU supplied'));
+        return;
     }
+    var pgt = this.pgtStore[pgtIOU]['pgtID'];
     
     var targetService = url.format(options);
     
@@ -785,8 +815,9 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
  * @param {Object} requestOptions
  *     Same as the options passed in to http.request(). This is where you 
  *     specify the service URL you are requesting.
- * @param {function} callback
+ * @param {Function} callback
  *     callback(err, req, res)
+ * @api public
  */
 CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callback) 
 {
@@ -823,9 +854,9 @@ CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callb
  * Parse a cas:authenticationSuccess XML node for CAS attributes.
  * Supports Jasig style, RubyCAS style, and Name-Value.
  *
- * @param {object} elemSuccess
+ * @param {Object} elemSuccess
  *     DOM node
- * @return {object}
+ * @return {Object}
  *     {
  *         attr1: [ attr1-val1, attr1-val2, ... ],
  *         attr2: [ attr2-val1, attr2-val2, ... ],

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -73,7 +73,7 @@ var jsdom = require('jsdom');
  *           An array of IP addresses of servers that we will accept
  *           single sign out requests from. Default is to accept all
  *           well-formed requests no matter where they are from.
- *           Only relevant if you use handleSignleSignout().
+ *           Only relevant if you use handleSingleSignout().
  *     }
  * @api public
  */
@@ -862,6 +862,7 @@ CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callb
  *         attr2: [ attr2-val1, attr2-val2, ... ],
  *         ...
  *     }
+ * @attribution http://downloads.jasig.org/cas-clients/php/1.2.0/docs/api/client_8php_source.html#l01589
  */
 var parseAttributes = function(elemSuccess) 
 {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -306,10 +306,10 @@ CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
     var logout_path;
     if (returnUrl && doRedirect) {
         // Logout with auto redirect
-        logout_path += '/logout?service=' + encodeURIComponent(returnUrl);
+        logout_path = '/logout?service=' + encodeURIComponent(returnUrl);
     } else if (returnUrl) {
         // Logout and provide a hyperlink back
-        logout_path += '/logout?url=' + encodeURIComponent(returnUrl);
+        logout_path = '/logout?url=' + encodeURIComponent(returnUrl);
     } else {
         // Logout with no way back
         logout_path = '/logout';

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -11,60 +11,169 @@
 
 var https = require('https');
 var url = require('url');
+var jsdom = require('jsdom');
+
+
 
 /**
  * Initialize CAS with the given `options`.
  *
  * @param {Object} options
+ *     { 
+ *       'base_url': The full URL to the CAS server, including the base path,
+ *       'service': The URL of the current page. Optional with authenticate(),
+ *       'version': Either 1.0 or 2.0
+ *     }
  * @api public
  */
 var CAS = module.exports = function CAS(options) {  
   options = options || {};
 
+  if (!options.version) {
+    // Can specify 1.0 or 2.0. Default is 1.0.
+    options.version = 1.0;
+  }
+  this.version = options.version;
+
   if (!options.base_url) {
     throw new Error('Required CAS option `base_url` missing.');
   } 
-
-  if (!options.service) {
-    throw new Error('Required CAS option `service` missing.');
-  }
 
   var cas_url = url.parse(options.base_url);
   if (cas_url.protocol != 'https:') {
     throw new Error('Only https CAS servers are supported.');
   } else if (!cas_url.hostname) {
-    throw new Error('Option `base_url` must be a valid url like: https://example.com/cas');    
+    throw new Error('Option `base_url` must be a valid url like: https://example.com/cas');
   } else {
-    this.hostname = cas_url.host;
+    this.hostname = cas_url.hostname;
     this.port = cas_url.port || 443;
     this.base_path = cas_url.pathname;
-  }  
+  }
   
   this.service = options.service;
+  
+  
+  this.tickets = {
+    'ST': null, // service ticket
+    'PT': null, // proxy ticket
+    'PGT': null, // proxy generating ticket
+    'PGTIOU': null // IOU for proxy generating ticket
+  };
 };
+
 
 /**
  * Library version.
  */
 
-CAS.version = '0.0.1';
+CAS.version = '0.0.4';
+
+
+
+/**
+ * Force CAS authentication on a web page. If users are not yet authenticated, 
+ * they will be redirected to the CAS server.
+ *
+ * @param {object} req
+ *      HTTP request object
+ * @param {object} res
+ *      HTTP response object
+ * @param {function} callback
+ *      Success callback: function(err, status, username, attributes) { ... }
+ */
+CAS.prototype.authenticate = function(req, res, callback)
+{
+    var casURL = 'https://' + this.hostname + ':' + this.port + this.base_path;
+    var ticket = req.param('ticket');
+    
+    // Set the return URL automatically if it wasn't manually provided
+    if (!this.service) {
+        // Get the URL of the current page
+        this.service = 'http://' + req.headers['host'] + req.url;
+    }
+    
+    // No ticket, so we haven't been sent to the CAS server yet
+    if (!ticket) {
+        // redirect to CAS server now
+        res.redirect(casURL + '/login?service=' + encodeURIComponent(this.service));
+    }
+
+    // We have a ticket! 
+    else {
+        this.tickets['ST'] = ticket;
+        // Validate it with the CAS server now
+        this.validate(ticket, callback);
+    }
+};
+
+
+
+/**
+ * Log the user out of their CAS session. The user will be redirected to
+ * the CAS server.
+ *
+ * @param {Object} req
+ *     HTTP request object
+ * @param {Object} res
+ *     HTTP response object
+ * @param {String} returnUrl
+ *     (optional) The URL that the user will return to after logging out.
+ * @param {Boolean} doRedirect
+ *     (optional) Set this to TRUE to have the CAS server redirect the user 
+ *      automatically. Default is for the CAS server to only provide a 
+ *      hyperlink to be clicked on.
+ */
+CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
+{
+    var logout_path;
+    if (returnUrl && doRedirect) {
+        // Logout with auto redirect
+        logout_path += '/logout?service=' + encodeURIComponent(returnUrl);
+    } else if (returnUrl) {
+        // Logout and provide a hyperlink back
+        logout_path += '/logout?url=' + encodeURIComponent(returnUrl);
+    } else {
+        // Logout with no way back
+        logout_path = '/logout';
+    }
+    
+    var casURL = 'https://' + this.hostname + ':' + this.port + this.base_path;
+    res.redirect(casURL + logout_path);
+}
+
+
 
 /**
  * Attempt to validate a given ticket with the CAS server.
- * `callback` is called with (err, auth_status, username)
+ * `callback` is called with (err, auth_status, username, attributes)
  *
  * @param {String} ticket
  * @param {Function} callback 
+ * @param {Boolean} renew (optional)
  * @api public
  */
+CAS.prototype.validate = function(ticket, callback, renew) {
+  // Use different CAS path depending on version
+  var validate_path;
+  if (this.version < 2.0) {
+    // CAS 1.0
+    validate_path = 'validate';
+  } else {
+    // CAS 2.0
+    validate_path = 'serviceValidate';
+  }
 
-CAS.prototype.validate = function(ticket, callback) {
+  if (!this.service) {
+    throw new Error('Required CAS option `service` missing.');
+  }
+
   var req = https.get({
     host: this.hostname,
     port: this.port,
     path: url.format({
-      pathname: this.base_path+'/validate',
-      query: {ticket: ticket, service: this.service}
+      "pathname": this.base_path+'/'+validate_path,
+      "query": {ticket: ticket, service: this.service},
+      "renew": renew
     })
   }, function(res) {
     // Handle server errors
@@ -80,19 +189,181 @@ CAS.prototype.validate = function(ticket, callback) {
     });
 
     res.on('end', function() {
-      var sections = response.split('\n');
-      if (sections.length >= 1) {
-        if (sections[0] == 'no') {
-          callback(undefined, false);
-          return;
-        } else if (sections[0] == 'yes' &&  sections.length >= 2) {
-          callback(undefined, true, sections[1]);
-          return;
+      // CAS 1.0
+      if (this.version < 2.0) {
+        var sections = response.split('\n');
+        if (sections.length >= 1) {
+          if (sections[0] == 'no') {
+            callback(undefined, false);
+            return;
+          } else if (sections[0] == 'yes' &&  sections.length >= 2) {
+            callback(undefined, true, sections[1]);
+            return;
+          }
         }
-      }
+        // Format was not correct, error
+        callback({message: 'Bad response format.'});
+      } 
+      
+      // CAS 2.0 (XML response, and optional attributes)
+      else {
+        // Use jsdom to parse the XML repsonse.
+        // ( Note:
+        //     It seems jsdom currently does not support XML namespaces.
+        //     And node names here are case insensitive. Hence attribute
+        //     names will also be case insensitive.
+        // )
+        //response = response.replace(/<cas:/, '<').replace(/<\/cas:/, '</');
+        jsdom.env(response, function(err, window) {
+            if (err) {
+                callback({message: 'jsdom could not parse response' + response});
+                return;
+            } else {
+                // Check for auth success
+                var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess');
+                elemSuccess = elemSuccess[0];
+                if (elemSuccess) {
+                    var elemUser = elemSuccess.getElementsByTagName('cas:user')[0];
+                    if (!elemUser) {
+                        //  no "user"??
+                        callback({'message': "No username?"}, false);
+                        return;
+                    } else {
+                        // Success
+                        var username = elemUser.textContent;
 
-      // Format was not correct, error
-      callback({message: 'Bad response format.'});
+                        var attributes = {};
+                        // Look for any optional attributes
+                        var elemAttribute = window.document.getElementsByTagName('cas:attributes')[0];
+                        if (elemAttribute && elemAttribute.hasChildNodes()) {
+                            // "Jasig Style" Attributes:
+                            // 
+                            //  <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                            //      <cas:authenticationSuccess>
+                            //          <cas:user>jsmith</cas:user>
+                            //          <cas:attributes>
+                            //              <cas:attraStyle>RubyCAS</cas:attraStyle>
+                            //              <cas:surname>Smith</cas:surname>
+                            //              <cas:givenName>John</cas:givenName>
+                            //              <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+                            //              <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
+                            //          </cas:attributes>
+                            //          <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
+                            //      </cas:authenticationSuccess>
+                            //  </cas:serviceResponse>
+                            //
+                            for (var i=0; i<elemAttribute.childNodes.length; i++) {
+                                var node = elemAttribute.childNodes[i];
+                                var attrName = node.nodeName.toLowerCase().replace(/cas:/, '');
+                                var attrValue = node.textContent;
+                                if (!attributes[attrName]) {
+                                    attributes[attrName] = [attrValue];
+                                } else {
+                                    attributes[attrName].push(attrValue);
+                                }
+                            }
+                        }
+                        
+                        else {
+                            // "RubyCAS Style" attributes
+                            // 
+                            //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                            //        <cas:authenticationSuccess>
+                            //            <cas:user>jsmith</cas:user>
+                            //                      
+                            //            <cas:attraStyle>RubyCAS</cas:attraStyle>
+                            //            <cas:surname>Smith</cas:surname>
+                            //            <cas:givenName>John</cas:givenName>
+                            //            <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+                            //            <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
+                            //                      
+                            //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
+                            //        </cas:authenticationSuccess>
+                            //    </cas:serviceResponse>
+                            // 
+                            for (var i=0; i<elemSuccess.childNodes.length; i++) {
+                                var node = elemSuccess.childNodes[i];
+                                var tagName = node.nodeName.toLowerCase().replace(/cas:/, '');
+                                switch (tagName) {
+                                    case 'user':
+                                    case 'proxies':
+                                    case 'proxygrantingticket':
+                                        // these are not CAS attributes
+                                        break;
+                                    default:
+                                        var attrName = tagName;
+                                        var attrValue = node.textContent;
+                                        if (attrValue != '') {
+                                            if (!attributes[attrName]) {
+                                                attributes[attrName] = [attrValue];
+                                            } else {
+                                                attributes[attrName].push(attrValue);
+                                            }
+                                        }
+                                        break;
+                                }
+                            }
+                        }
+                        
+                        if (attributes == {}) {
+                            // "Name-Value" attributes.
+                            // 
+                            // Attribute format from this mailing list thread:
+                            // http://jasig.275507.n4.nabble.com/CAS-attributes-and-how-they-appear-in-the-CAS-response-td264272.html
+                            // Note: This is a less widely used format, but in use by at least two institutions.
+                            // 
+                            //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                            //        <cas:authenticationSuccess>
+                            //            <cas:user>jsmith</cas:user>
+                            //                      
+                            //            <cas:attribute name='attraStyle' value='Name-Value' />
+                            //            <cas:attribute name='surname' value='Smith' />
+                            //            <cas:attribute name='givenName' value='John' />
+                            //            <cas:attribute name='memberOf' value='CN=Staff,OU=Groups,DC=example,DC=edu' />
+                            //            <cas:attribute name='memberOf' value='CN=Spanish Department,OU=Departments,...' />
+                            //                      
+                            //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
+                            //        </cas:authenticationSuccess>
+                            //    </cas:serviceResponse>
+                            //
+                            var nodes = elemSuccess.getElementsByTagName('cas:attribute');
+                            if (nodes && nodes.length) {
+                                for (var i=0; i<nodes.length; i++) {
+                                    var attrName = nodes[i].getAttribute('name');
+                                    var attrValue = nodes[i].getAttribute('value');
+                                    if (!attributes[attrName]) {
+                                        attributes[attrName] = [attrValue];
+                                    } else {
+                                        attributes[attrName].push(attrValue);
+                                    }
+                                }
+                            }
+                        }
+                        
+                        //console.log(attributes);
+                        callback(undefined, true, username, attributes);
+                        return;
+                    }
+                } // end if auth success
+
+                // Check for correctly formatted auth failure message
+                var elemFailure = window.document.getElementsByTagName('cas:authenticationFailure')[0];
+                if (elemFailure) {
+                    var code = elemFailure.getAttribute('code');
+                    var message = 'Login failed: ';
+                    message += elemFailure.textContent;
+                    callback({ 'code': code, 'message': message }, false);
+                    return;
+                }
+
+                // The response was not in any expected format, error
+                callback({message: 'Bad response format.'});
+                return;
+            }
+        });
+        
+      };
+
     });
   });
 };

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -615,11 +615,10 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
             callback(err);
             return;
         }
-        //console.log('Proxied Request -- got PT: ' + pt);
         
         // Add the proxy ticket to the target service's query string
         var path = options.path || targetService.replace(/^https?:\/\/[^\/]+/, '');
-        if (path.indexOf('&') >= 0) {
+        if (path.match(/[&?]/)) {
             options.path = path + '&ticket=' + pt;
         } else {
             options.path = path + '?ticket=' + pt;

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -536,9 +536,15 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
                 callback(err);
             });
         });
+        
+        // Error starting the connection to the PGT server
+        req.on('error', function(err) {
+            callback(err);
+            req.abort();
+        });
         return null;
     }
-
+    
     // Look up the PGT locally
     else if (this.pgtStore[pgtIOU]) {
         pgt = this.pgtStore[pgtIOU]['pgtID'];
@@ -637,6 +643,12 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
                     return;
                 });
             });
+        });
+
+        // Error starting the connection to the CAS server
+        req.on('error', function(err) {
+            callback(err);
+            req.abort();
         });
     });
 }

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -4,6 +4,8 @@
  * Copyright(c) 2011 Casey Banner <kcbanner@gmail.com>
  * MIT Licensed
  *
+ * 2.0 additions by Joshua Chan <joshua@appdevdesigns.net>
+ *
  * A Node.js CAS client, implementing the protocol as defined at:
  * http://www.jasig.org/cas/protocol
  */
@@ -27,49 +29,48 @@ var jsdom = require('jsdom');
  *       'base_url': 
  *           The full URL to the CAS server, including the base path.
  *       'service': 
- *           The URL of the current page. Optional with authenticate().
+ *           The URL of the page being authenticated. Can be omitted here and
+ *           specified during validate(). Or detected automatically during
+ *           authenticate().
  *       'version': 
  *           Either 1.0 or 2.0
  *
- *       'external_pgt_url': 
- *           (optional) The URL of the external proxy's PGT callback.
- *           e.g. https://proxy.example.com:8989/
+ *
+ *       'external_pgt_url':
+ *           (optional) The URL of the PGT callback server.
+ *           e.g. https://callback.example.com:8989/
  *           The CAS server will try to contact this host every time a user 
  *           logs in. 
- *           Do not use with the `proxy_server` option.
- *       'external_proxy_url':
- *           (optional) The URL of the external CAS proxy. The protocol, 
- *           hostname, and port number are required. The path will be ignored.
- *           e.g. https://proxy.example.com:8080/
- *           Should be used together with the `external_pgt_url` option.
- *           The CAS client will use this URL to make proxied requests.
+ *           Do not use with the `pgt_server` option.
  *
- *       'proxy_server': 
+ *
+ *       'pgt_server': (previously 'proxy_server')
  *           (optional) Set to TRUE if you want to automatically start 
- *           a proxy callback server internally.
- *           Do not use with `external_pgt_url`.
- *           The CAS client will use this internal server to make proxied 
- *           requests.
- *       'proxy_server_port':
- *           (optional) The port to listen on for external proxy requests for 
- *           a CAS enabled service.
- *           Disabled by default.
- *       'proxy_callback_host':
- *           The publicly accessible host name of your callback server.
+ *           a PGT callback server internally.
+ *           Can be used to create a standalone PGT callback server.
+ *           Do not combine with `external_pgt_url`.
+ *
+ *       'pgt_host': (previously 'proxy_callback_host')
+ *           The publicly accessible host name of your PGT server.
  *           It must be usable by the CAS server. The CAS server will try to
  *           contact this host every time a user logs in.
- *           Required only if you used `proxy_server`.
- *       'proxy_callback_port':
+ *           Required only if you used `pgt_server`.
+ *
+ *       'pgt_port': (previously 'proxy_callback_port')
  *           (optional) The port to listen on for incoming connections from
- *           the CAS server. Used with `proxy_callback_host`. Default is 80443.
- *       'proxy_server_key':
+ *           the CAS server. Used with `pgt_host`. Default is 80443.
+ *
+ *       'ssl_key': (previously 'proxy_server_key')
  *           A string value of your SSL private key. 
- *           Required only if you used `proxy_server`.
- *       'proxy_server_cert':
+ *           Required only if you used `pgt_server`.
+ *
+ *       'ssl_cert': (previously 'proxy_server_cert')
  *           A string value of your SSL certificate. 
- *           Required only if you used `proxy_server`.
- *       'proxy_server_ca':
+ *           Required only if you used `pgt_server`.
+ *
+ *       'ssl_ca': (previously 'proxy_server_ca')
  *           (optional) An array of SSL CA and Intermediate CA certificates.
+ *
  *
  *       'sso_servers':
  *           An array of IP addresses of servers that we will accept
@@ -82,12 +83,14 @@ var jsdom = require('jsdom');
 var CAS = module.exports = function CAS(options) 
 {  
   options = options || {};
-
-  if (!options.version) {
-    // Can specify 1.0 or 2.0. Default is 1.0.
-    options.version = 1.0;
-  }
-  this.version = options.version;
+  
+  // Backwards compatibility for old option names
+  options.pgt_server = options.pgt_server || options.proxy_server;
+  options.pgt_host = options.pgt_host || options.proxy_callback_host;
+  options.pgt_port = options.pgt_port || options.proxy_callback_port;
+  options.ssl_key = options.ssl_key || options.proxy_server_key;
+  options.ssl_cert = options.ssl_cert || options.proxy_server_cert;
+  options.ssl_ca = options.ssl_ca || options.proxy_server_ca;
 
   if (!options.base_url) {
     throw new Error('Required CAS option `base_url` missing.');
@@ -101,7 +104,7 @@ var CAS = module.exports = function CAS(options)
     throw new Error('Option `base_url` must be a valid url like: https://example.com/cas');
   } 
   
-  
+  this.version = options.version || 1.0;
   this.hostname = cas_url.hostname;
   this.port = cas_url.port || 443;
   this.base_path = cas_url.pathname;
@@ -114,7 +117,7 @@ var CAS = module.exports = function CAS(options)
     this.ssoServers = options.sso_servers;
   }
 
-  // User has supplied an external PGT callback URL
+  // External PGT callback server URL
   if (options.external_pgt_url) {
     var pgt_url = url.parse(options.external_pgt_url);
     if (pgt_url.protocol != 'https:') {
@@ -126,8 +129,7 @@ var CAS = module.exports = function CAS(options)
     this.is_pgt_external = true;
     this.pgt_url = url.format(pgt_url);
     
-    // A PGT callback URL is only useful if you also have a proxy URL to 
-    // go with it.
+    // Deprecated
     if (options.external_proxy_url) {
       var proxy_url = url.parse(options.external_proxy_url);
       if (!proxy_url.hostname) {
@@ -137,27 +139,27 @@ var CAS = module.exports = function CAS(options)
     }
   }
 
-  // User is requesting the internal proxy server
-  else if (options.proxy_server) {
+  // Internal PGT callback server
+  else if (options.pgt_server) {
     //// Required
     // (openssl genrsa -out privatekey.pem 1024)
-    this.proxy_server_key = options.proxy_server_key;
+    this.ssl_key = options.ssl_key;
     // (openssl req -new -key privatekey.pem -out csr.pem)
     // (openssl x509 -req -in csr.pem -signkey privatekey.pem -out cert.pem)
-    this.proxy_server_cert = options.proxy_server_cert;
-    if (!this.proxy_server_key || !this.proxy_server_cert) {
-        throw new Error('Options `proxy_server_key` and `proxy_server_cert` are required because you specified `proxy_server`');
+    this.ssl_cert = options.ssl_cert;
+    if (!this.ssl_key || !this.ssl_cert) {
+        throw new Error('Options `ssl_key` and `ssl_cert` are required because you specified `pgt_server`');
     }
-    this.proxy_callback_host = options.proxy_callback_host;
-    if (!this.proxy_callback_host) {
-        throw new Error('Option `proxy_callback_host` is required because you specified `proxy_server`');
+    this.pgt_host = options.pgt_host;
+    if (!this.pgt_callback_host) {
+        throw new Error('Option `pgt_callback_host` is required because you specified `pgt_server`');
     }
     //// Optional
-    this.proxy_server_port = options.proxy_server_port || 0;
-    this.proxy_callback_port = options.proxy_callback_port || 80443
-    this.proxy_server_ca = options.proxy_server_ca || [];
+    this.proxy_server_port = options.proxy_server_port || 0; // deprecated
+    this.pgt_port = options.pgt_port || 80443
+    this.ssl_ca = options.ssl_ca || [];
     
-    this.startProxyServer(this.proxy_server_key, this.proxy_server_cert, this.proxy_server_ca, this.proxy_callback_host, this.proxy_callback_port, this.proxy_server_port);
+    this.startPgtServer(this.ssl_key, this.ssl_cert, this.ssl_ca, this.pgt_host, this.pgt_port, this.proxy_server_port);
   }
 
 };
@@ -167,7 +169,7 @@ var CAS = module.exports = function CAS(options)
  * Library version.
  */
 
-CAS.version = '0.0.4';
+CAS.version = '0.0.5';
 
 
 
@@ -182,8 +184,8 @@ CAS.version = '0.0.4';
  * @param {function} callback
  *      callback(err, status, username, extended)
  * @param {String} service
- *      (optional) The URL of the service/page that is requesting 
- *      authentication. Default is to extract this automatically from
+ *      (optional) The URL of the service/page that requires authentication. 
+ *      Default is to extract this automatically from
  *      the `req` object.
  * @api public
  */
@@ -195,14 +197,13 @@ CAS.prototype.authenticate = function(req, res, callback, service)
     // Try to extract the CAS ticket from the URL
     var ticket = reqURL.query['ticket'];
 
-    // Obtain the service URL automatically if it wasn't provided during 
-    // initialization.
+    // Obtain the service URL automatically if it wasn't provided
     if (!service) {
         // Get the URL of the current page, minus the 'ticket'
         delete reqURL.query['ticket'];
         service = url.format({
             protocol: req.protocol || 'http',
-            host: req.headers['host'],
+            host: req.headers['x-forwarded-host'] || req.headers['host'],
             pathname: reqURL.pathname,
             query: reqURL.query
         });
@@ -268,7 +269,7 @@ CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
                 if (ticketElem) {
                     // This is the ticket that was issued by CAS when the user
                     // first logged in. Pass it into the callback so the
-                    // framework can use it to delete the user's session.
+                    // application can use it to delete the user's session.
                     var ticket = ticketElem.textContent.trim();
                     return logoutCallback(ticket);
                 }
@@ -518,12 +519,15 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
 {
     var pgt = '';
     
-    // If configured for external proxy server use, fetch the PT from there
+    // If configured for external PGT server use, fetch the PT from there
     if (this.is_pgt_external) {
         var urlFetchPGT = url.parse(this.pgt_url + 'getPGT?pgtiou=' + pgtIOU);
-        https.get(urlFetchPGT, function(res) {
+        var req = https.get(urlFetchPGT, function(res) {
             res.on('data', function(chunk) {
                 pgt += chunk;
+                if (pgt.length > 1e6) {
+                  req.connection.destroy();
+                }
             });
             res.on('end', function() {
                 callback(null, pgt);
@@ -553,12 +557,19 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
  * Obtain a Proxy Ticket (PT) that can be used to access a service on behalf
  * of a user.
  *
- * Used internally by proxiedRequest(), but you may also use it to manually
- * assemble proxied requests by other means.
+ * Example:
+ *      var url = 'http://example.com/user/info';
+ *      cas.getProxyTicket(pgtiou, url, function(err, pt) {
+ *          if (!err) {
+ *              url += '?ticket=' + pt;
+ *              request(url, ... )
+ *          }
+ *      });
  *
  * @param {string} pgtIOU
  *      The PGTIOU that was given by the CAS server when the user logged in.
  * @param {function} callback
+ *      The user's authentication ticket will be delivered via this function
  *      callback(err, pt)
  */
 CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback) 
@@ -602,7 +613,7 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
                 // Use jsdom to parse the XML response
                 jsdom.env(response, function(err, window) {
                     if (err) {
-                        callback(new Error("jsdom could not parse response: " + response));
+                        callback(new Error("Could not parse response: " + response));
                         return;
                     }
                     // Got the proxy ticket
@@ -632,21 +643,25 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
 
 
 /**
- * Start a local proxy server.
+ * Start a PGT callback server.
  * 
  * This is a local HTTPS server that listens for incoming connections from 
  * the CAS server. Any PGTs received from the CAS server will be stored
  * in `this.pgtStore`.
  *
- * This is optionally also a proxy server that listens for outgoing proxy 
+ * The local machine and the CAS server must be able to access each other
+ * on the network.
+ *
+ *
+ * The following functionality is deprecated:
+ *
+ * This is optionally also an http proxy server that listens for outgoing 
  * requests from clients that already have a PGTIOU. In addition to the 
  * normal HTTP information, the client must also supply these two headers 
  * in the request:
  *    cas-proxy-pgtiou
  *    cas-proxy-targeturl
  *
- * For this to work, the local machine and the CAS server must be able to 
- * access each other on the network.
  *
  * @param {String/Buffer} key
  *    The SSL private key
@@ -659,12 +674,13 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
  * @param {Integer} callbackPort
  *    The port number to listen on for incoming CAS PGT messages.
  * @param {Integer} proxyPort
+ *    Deprecated.
  *    The port number to listen on for outgoing proxied requests.
  *    Omit this to disable the proxy server and only allow
  *    internal requests via CAS.proxiedRequest().
  * @api public
  */
-CAS.prototype.startProxyServer = function(key, cert, ca, callbackHost, callbackPort, proxyPort) 
+CAS.prototype.startPgtServer = function(key, cert, ca, callbackHost, callbackPort, proxyPort) 
 {
     var serverOptions = {
         'key': key,
@@ -708,7 +724,7 @@ CAS.prototype.startProxyServer = function(key, cert, ca, callbackHost, callbackP
         else {
             res.writeHead(200, {'Content-Type': 'text/plain'});
             res.end();
-            // Save the PGT ticket into the memory store
+            // Save the PGT info into the memory store
             var pgtIOU = reqURL.query['pgtIou'];
             var pgtID = reqURL.query['pgtId'];
             if (pgtIOU && pgtID) {
@@ -737,11 +753,13 @@ CAS.prototype.startProxyServer = function(key, cert, ca, callbackHost, callbackP
         }
     }, 1000 * 60);
     
+    
+    // Deprecated:
     // Proxy server that listens for HTTPS connections from other CAS clients
     // and forwards them to the target service. Disabled by default.
     if (proxyPort) {
         var proxyServer = https.createServer(serverOptions);
-        console.log('Starting CAS proxy server on port ' + proxyPort);
+        console.log('Starting CAS-aware HTTP proxy server on port ' + proxyPort);
         proxyServer.addListener("request", function(req, res) {
             // Use "cas-proxy-..." headers to obtain information about the 
             // requested target service.
@@ -813,6 +831,8 @@ CAS.prototype.startProxyServer = function(key, cert, ca, callbackHost, callbackP
  * Create a CAS proxied HTTP/HTTPS request.
  * The CAS proxy ticket (PT) will automatically be added to the target 
  * service's query.
+ *
+ * Deprecated.
  *
  * @param {String} pgtIOU
  *     This should have been obtained during the initial CAS login with
@@ -893,8 +913,10 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
 /**
  * Create a CAS proxied HTTP/HTTPS request through an external server.
  *
+ * Deprecated.
+ *
  * @param {String} proxyURL
- *     The URL of the CAS proxy server
+ *     The URL of the CAS http proxy server
  * @param {String} pgtIOU
  *     This should have been obtained during the initial CAS login with
  *     the validate() function.

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -29,7 +29,15 @@ var jsdom = require('jsdom');
  *           Either 1.0 or 2.0
  *
  *       'external_pgt_url': 
- *           (optional) The URL of an external proxy's PGT callback.
+ *           (optional) The URL of the external proxy's PGT callback.
+ *           e.g. https://proxy.example.com:8989/
+ *           Do not use with the `proxy_server` option.
+ *       'external_proxy_url':
+ *           (optional) The URL of the external CAS proxy. The protocol, 
+ *           hostname, and port number are required. The path will be ignored.
+ *           e.g. https://proxy.example.com:8080/
+ *           Should be used together with the `external_pgt_url` option.
+ *
  *       'proxy_server': 
  *           (optional) Set to TRUE if you want to automatically start 
  *           a proxy callback server locally.
@@ -54,7 +62,8 @@ var jsdom = require('jsdom');
  *     }
  * @api public
  */
-var CAS = module.exports = function CAS(options) {  
+var CAS = module.exports = function CAS(options) 
+{  
   options = options || {};
 
   if (!options.version) {
@@ -82,18 +91,29 @@ var CAS = module.exports = function CAS(options) {
   this.service = options.service;
   this.pgtStore = {};
 
-  // User has supplied their own PGT callback URL
+  // User has supplied an external PGT callback URL
   if (options.external_pgt_url) {
     var pgt_url = url.parse(options.external_pgt_url);
     if (pgt_url.protocol != 'https:') {
-      throw new Error('Option `pgt_url` must be https');
+      throw new Error('Option `external_pgt_url` must be https');
     }
     if (!pgt_url.hostname) {
-      throw new Error('Option `pgt_url` must be a valid url like: https://example.com/callback');
+      throw new Error('Option `external_pgt_url` must be a valid url like: https://example.com:8989/callback');
     }
-    this.pgt_url = options.external_pgt_url;
+    this.pgt_url = url.format(pgt_url);
+    
+    // A PGT callback URL is only useful if you also have a proxy URL to 
+    // go with it.
+    if (options.external_proxy_url) {
+      var proxy_url = url.parse(options.external_proxy_url);
+      if (!proxy_url.hostname) {
+        throw new Error('Option `external_proxy_url` must be a vald url like: https://example.com:8080');
+      }
+      this.external_proxy_url = url.format(proxy_url);
+    }
+    
   }
-  // User is requesting the built-in proxy server
+  // User is requesting the internal proxy server
   else if (options.proxy_server) {
     //// Required
     // (openssl genrsa -out privatekey.pem 1024)
@@ -128,7 +148,7 @@ CAS.version = '0.0.4';
 
 /**
  * Force CAS authentication on a web page. If users are not yet authenticated, 
- * they will be redirected to the CAS server.
+ * they will be redirected to the CAS server to log in there.
  *
  * @param {object} req
  *      HTTP request object
@@ -149,7 +169,8 @@ CAS.prototype.authenticate = function(req, res, callback, service)
     // Try to extract the CAS ticket from the URL
     var ticket = reqURL.query['ticket'];
 
-    // Set the service URL automatically if it wasn't manually provided
+    // Obtain the service URL automatically if it wasn't provided during 
+    // initialization.
     if (!service) {
         // Get the URL of the current page, minus the 'ticket'
         delete reqURL.query['ticket'];
@@ -182,7 +203,7 @@ CAS.prototype.authenticate = function(req, res, callback, service)
 
 /**
  * Log the user out of their CAS session. The user will be redirected to
- * the CAS server.
+ * the CAS server for this.
  *
  * @param {Object} req
  *     HTTP request object
@@ -227,14 +248,15 @@ CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
  *     callback(err, auth_status, username, extended)
  * @param {String} service
  *     The URL of the service requesting authentication. Optional if
- *     the `service` option was specified during initialization.
+ *     the `service` option was already specified during initialization.
  * @param {Boolean} renew 
  *     (optional) Set this to TRUE to force the CAS server to request
  *     credentials from the user even if they had already done so
  *     recently.
  * @api public
  */
-CAS.prototype.validate = function(ticket, callback, service, renew) {
+CAS.prototype.validate = function(ticket, callback, service, renew) 
+{
   // Use different CAS path depending on version
   var validate_path;
   var pgtURL;
@@ -398,7 +420,8 @@ CAS.prototype.validate = function(ticket, callback, service, renew) {
  * @param {function} callback
  *      callback(err, pt)
  */
-CAS.prototype.getProxyTicket = function(pgt, targetService, callback) {
+CAS.prototype.getProxyTicket = function(pgt, targetService, callback) 
+{
     var req = https.get({
         host: this.hostname,
         port: this.port,
@@ -483,7 +506,8 @@ CAS.prototype.getProxyTicket = function(pgt, targetService, callback) {
  *    Omit this to disable the proxy server and only allow
  *    internal requests via CAS.proxiedRequest().
  */
-CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort, proxyPort) {
+CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort, proxyPort) 
+{
     var serverOptions = {
         'key': key,
         'cert': cert
@@ -600,7 +624,13 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
  * @param {function} callback
  *     callback(err, req, res)
  */
-CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
+CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) 
+{
+    if (this.external_proxy_url) {
+        this.proxiedRequestExternal(this.external_proxy_url, pgtIOU, options, callback);
+        return;
+    }
+
     // Look up the PGT using the PGTIOU
     var pgt = this.pgtStore[pgtIOU];
     if (!pgt) {
@@ -650,6 +680,55 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
 
 
 /**
+ * Create a CAS proxied HTTP/HTTPS request through an external server.
+ *
+ * @param {String} proxyURL
+ *     The URL of the CAS proxy server
+ * @param {String} pgtIOU
+ *     This should have been obtained during the initial CAS login with
+ *     the validate() function.
+ * @param {Object} requestOptions
+ *     Same as the options passed in to http.request(). This is where you 
+ *     specify the service URL you are requesting.
+ * @param {function} callback
+ *     callback(err, req, res)
+ */
+CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callback) 
+{
+    if (!this.external_proxy_url) {
+        throw new Error('Option `external_proxy_url` is required in order to use proxiedRequestExternal()');
+    }
+    
+    var targetService = url.format(options);
+    var proxyInfo = url.parse(proxyURL);
+
+    // Add the target's path (and querystring) to the proxy request.
+    proxyInfo.path = options.path;
+
+    // Add the custom proxy headers
+    var headers = options.headers || {};
+    headers['cas-proxy-pgtiou'] = pgtIOU;
+    headers['cas-proxy-targeturl'] = targetService;
+    proxyInfo.headers = headers;
+
+    var serviceObj;
+    if (proxyInfo.protocol.indexOf('https') == 0) {
+        serviceObj = https;
+    } else {
+        serviceObj = http;
+    }
+    
+    try {
+        var req = serviceObj.get(proxyInfo, function(res) {
+            callback(undefined, req, res);
+        });
+    } catch(e) {
+        callback(e);
+    }
+}
+
+
+/**
  * Parse a cas:authenticationSuccess XML node for CAS attributes.
  * Supports Jasig style, RubyCAS style, and Name-Value.
  *
@@ -662,7 +741,8 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
  *         ...
  *     }
  */
-var parseAttributes = function(elemSuccess) {
+var parseAttributes = function(elemSuccess) 
+{
     var attributes = {};
     var elemAttribute = elemSuccess.getElementsByTagName('cas:attributes')[0];
     if (elemAttribute && elemAttribute.hasChildNodes()) {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -60,16 +60,23 @@ var jsdom = require('jsdom');
  *           (optional) The port to listen on for incoming connections from
  *           the CAS server. Used with `pgt_host`. Default is 80443.
  *
+ *
  *       'ssl_key': (previously 'proxy_server_key')
  *           A string value of your SSL private key. 
- *           Required only if you used `pgt_server`.
+ *           Required for `pgt_server`.
+ *           Optional for `external_pgt_url`.
+ *           Not needed otherwise.
  *
  *       'ssl_cert': (previously 'proxy_server_cert')
  *           A string value of your SSL certificate. 
- *           Required only if you used `pgt_server`.
+ *           Required for `pgt_server`.
+ *           Optional for `external_pgt_url`.
+ *           Not needed otherwise.
  *
  *       'ssl_ca': (previously 'proxy_server_ca')
  *           (optional) An array of SSL CA and Intermediate CA certificates.
+ *           Useful with `external_pgt_url` if the PGT callback server has a
+ *           self signed certificate.
  *
  *
  *       'sso_servers':
@@ -112,6 +119,12 @@ var CAS = module.exports = function CAS(options)
   this.pgtStore = {};
   this.pgt_is_external = false;
   
+  // SSL options used when running a PGT callback server,
+  // or as a client contacting the external PGT URL.
+  this.ssl_cert = options.ssl_cert || null;
+  this.ssl_key = options.ssl_key || null;
+  this.ssl_ca = options.ssl_ca || [];
+  
   // Optional single sign out server list
   if (options.sso_servers) {
     this.ssoServers = options.sso_servers;
@@ -142,22 +155,16 @@ var CAS = module.exports = function CAS(options)
   // Internal PGT callback server
   else if (options.pgt_server) {
     //// Required
-    // (openssl genrsa -out privatekey.pem 1024)
-    this.ssl_key = options.ssl_key;
-    // (openssl req -new -key privatekey.pem -out csr.pem)
-    // (openssl x509 -req -in csr.pem -signkey privatekey.pem -out cert.pem)
-    this.ssl_cert = options.ssl_cert;
     if (!this.ssl_key || !this.ssl_cert) {
         throw new Error('Options `ssl_key` and `ssl_cert` are required because you specified `pgt_server`');
     }
     this.pgt_host = options.pgt_host;
-    if (!this.pgt_callback_host) {
-        throw new Error('Option `pgt_callback_host` is required because you specified `pgt_server`');
+    if (!this.pgt_host) {
+        throw new Error('Option `pgt_host` is required because you specified `pgt_server`');
     }
     //// Optional
     this.proxy_server_port = options.proxy_server_port || 0; // deprecated
     this.pgt_port = options.pgt_port || 80443
-    this.ssl_ca = options.ssl_ca || [];
     
     this.startPgtServer(this.ssl_key, this.ssl_cert, this.ssl_ca, this.pgt_host, this.pgt_port, this.proxy_server_port);
   }
@@ -522,6 +529,10 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
     // If configured for external PGT server use, fetch the PT from there
     if (this.is_pgt_external) {
         var urlFetchPGT = url.parse(this.pgt_url + 'getPGT?pgtiou=' + pgtIOU);
+        urlFetchPGT.key = this.ssl_key || null;
+        urlFetchPGT.cert = this.ssl_cert || null;
+        urlFetchPGT.ca = this.ssl_ca || null;
+        
         var req = https.get(urlFetchPGT, function(res) {
             res.on('data', function(chunk) {
                 pgt += chunk;
@@ -577,6 +588,7 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
  * @param {function} callback
  *      The user's authentication ticket will be delivered via this function
  *      callback(err, pt)
+ * @api public
  */
 CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback) 
 {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -202,6 +202,61 @@ CAS.prototype.authenticate = function(req, res, callback, service)
 
 
 /**
+ * Handle a single sign-out request from the CAS server. 
+ *
+ * In CAS 3.x the server keeps track of all the `ticket` and `service` values
+ * associated with each user. Then when the user logs out from one site, the
+ * server will contact every `service` they have authenticated with and POST
+ * a sign-out request containing the original `ticket` used to login.
+ *
+ * This is optional. But if you do use this, it must come before authenticate().
+ * Also, it will only work if the service is accessible on the network by the 
+ * CAS server.
+ *
+ * Unlike the other functions in this module, this one will only work 
+ * with Express or something else that pre-processes the body of a POST 
+ * request. It is not compatible with basic node.js http req objects.
+ *
+ * @param {Object} req
+ *      Express/Connect http serverRequest
+ * @param {Object} res
+ *      http serverResponse
+ * @param {Function} next
+        Normal callback if no logout request was made.
+ * @param {Function} logoutCallback
+ *      function(ticket)
+ */
+CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
+{
+    if (req.method == 'POST' && req.body['logoutRequest']) {
+        // This was a signout request. Parse the XML.
+        jsdom.env(req.body['logoutRequest'], function(err, window) {
+            if (!err) {
+                var ticketElem = window.document.getElementsByTagName('samlp:SessionIndex')[0];
+                if (ticketElem) {
+                    // This is the ticket that was issued by CAS when the user
+                    // first logged in. Pass it into the callback so the
+                    // framework can delete the user's session based on that.
+                    var ticket = ticketElem.textContent
+                        .replace(/^\s+/, '')
+                        .replace(/\s+$/, '');
+                    logoutCallback(ticket);
+                    return;
+                }
+            }
+            // This was not a valid signout request.
+            next();
+        });
+    }
+    else {
+        // This was not a signout request. Proceed normally.
+        next();
+    }
+}
+
+
+
+/**
  * Log the user out of their CAS session. The user will be redirected to
  * the CAS server for this.
  *
@@ -245,7 +300,13 @@ CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
  * @param {String} ticket
  *     Either a service ticket (ST) or a proxy ticket (PT)
  * @param {Function} callback
- *     callback(err, auth_status, username, extended)
+ *     callback(err, auth_status, username, extended).
+ *     `extended` is an object containing:
+ *       - username
+ *       - attributes
+ *       - PGTIOU
+ *       - ticket
+ *       - proxies
  * @param {String} service
  *     The URL of the service requesting authentication. Optional if
  *     the `service` option was already specified during initialization.
@@ -388,6 +449,7 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
                     'username': username,
                     'attributes': attributes,
                     'PGTIOU': pgtIOU,
+                    'ticket': ticket,
                     'proxies': proxies
                 });
                 return;

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -313,6 +313,9 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
     var response = '';
     res.on('data', function(chunk) {
       response += chunk;
+      if (response.length > 1e6) {
+        req.connection.destroy();
+      }
     });
 
     res.on('end', function() {
@@ -443,6 +446,9 @@ CAS.prototype.getProxyTicket = function(pgt, targetService, callback)
         var response = '';
         res.on('data', function(chunk) {
             response += chunk;
+            if (response.length > 1e6) {
+                req.connection.destroy();            
+            }
         });
         res.on('end', function() {
             // Use jsdom to parse the XML response

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -497,7 +497,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     // PGT callback server that listens for incoming connections from
     // the CAS server.
     var pgtServer = https.createServer(serverOptions);
-    console.log('Starting PGT callback server');
+    console.log('Starting PGT callback server on port ' + callbackPort);
     pgtServer.addListener("request", function(req, res) {
         res.writeHead(200, {'Content-Type': 'text/plain'});
         res.end();
@@ -509,7 +509,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
             self.pgtStore[ pgtIOU ] = pgtID;
             //console.log('Callback -- got PGT: ' + pgtID);
         } else {
-            //console.error('Callback -- Got unrecognized request:' + req.method + ' ' + req.url);
+            //console.error('Callback -- Got unrecognized request: ' + req.method + ' ' + req.url);
         }
     });
     pgtServer.listen(callbackPort);
@@ -518,7 +518,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     // the target service. Disabled by default.
     if (proxyPort) {
         var proxyServer = https.createServer(serverOptions);
-        console.log('Starting CAS proxy server');
+        console.log('Starting CAS proxy server on port ' + proxyPort);
         proxyServer.addListener("request", function(req, res) {
             // Use "cas-proxy-..." headers to obtain information about the 
             // requested target service.

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -9,6 +9,7 @@
  * Module dependencies
  */
 
+var http = require('http');
 var https = require('https');
 var url = require('url');
 var jsdom = require('jsdom');
@@ -20,9 +21,36 @@ var jsdom = require('jsdom');
  *
  * @param {Object} options
  *     { 
- *       'base_url': The full URL to the CAS server, including the base path,
- *       'service': The URL of the current page. Optional with authenticate(),
- *       'version': Either 1.0 or 2.0
+ *       'base_url': 
+ *           The full URL to the CAS server, including the base path.
+ *       'service': 
+ *           The URL of the current page. Optional with authenticate().
+ *       'version': 
+ *           Either 1.0 or 2.0
+ *
+ *       'external_pgt_url': 
+ *           (optional) The URL of an external proxy's PGT callback.
+ *       'proxy_server': 
+ *           (optional) Set to TRUE if you want to automatically start 
+ *           a proxy callback server locally.
+ *           Do not use with `external_pgt_url`.
+ *       'proxy_server_port':
+ *           (optional) The port to listen on for outgoing requests that are
+ *           to be forwarded to an external CAS enabled service.
+ *           Disabled by default.
+ *       'proxy_callback_host':
+ *           The publicly accessible host name of your callback server.
+ *           It must be usable by the CAS server.
+ *           Required only if you used `proxy_server`.
+ *       'proxy_callback_port':
+ *           (optional) The port to listen on for incoming connections from
+ *           the CAS server. Default is 80443.
+ *       'proxy_server_key':
+ *           A string value of your SSL private key. 
+ *           Required only if you used `proxy_server`.
+ *       'proxy_server_cert':
+ *           A string value of your SSL certificate. 
+ *           Required only if you used `proxy_server`.
  *     }
  * @api public
  */
@@ -42,23 +70,51 @@ var CAS = module.exports = function CAS(options) {
   var cas_url = url.parse(options.base_url);
   if (cas_url.protocol != 'https:') {
     throw new Error('Only https CAS servers are supported.');
-  } else if (!cas_url.hostname) {
+  } 
+  if (!cas_url.hostname) {
     throw new Error('Option `base_url` must be a valid url like: https://example.com/cas');
-  } else {
-    this.hostname = cas_url.hostname;
-    this.port = cas_url.port || 443;
-    this.base_path = cas_url.pathname;
-  }
+  } 
   
+  
+  this.hostname = cas_url.hostname;
+  this.port = cas_url.port || 443;
+  this.base_path = cas_url.pathname;
   this.service = options.service;
-  
-  
-  this.tickets = {
-    'ST': null, // service ticket
-    'PT': null, // proxy ticket
-    'PGT': null, // proxy generating ticket
-    'PGTIOU': null // IOU for proxy generating ticket
-  };
+  this.pgtStore = {};
+
+  // User has supplied their own PGT callback URL
+  if (options.external_pgt_url) {
+    var pgt_url = url.parse(options.external_pgt_url);
+    if (pgt_url.protocol != 'https:') {
+      throw new Error('Option `pgt_url` must be https');
+    }
+    if (!pgt_url.hostname) {
+      throw new Error('Option `pgt_url` must be a valid url like: https://example.com/callback');
+    }
+    this.pgt_url = options.external_pgt_url;
+  }
+  // User is requesting the built-in proxy server
+  else if (options.proxy_server) {
+    //// Required
+    // (openssl genrsa -out privatekey.pem 1024)
+    this.proxy_server_key = options.proxy_server_key;
+    // (openssl req -new -key privatekey.pem -out csr.pem)
+    // (openssl x509 -req -in csr.pem -signkey privatekey.pem -out cert.pem)
+    this.proxy_server_cert = options.proxy_server_cert;
+    if (!this.proxy_server_key || !this.proxy_server_cert) {
+        throw new Error('Options `proxy_server_key` and `proxy_server_cert` are required because you specified `proxy_server`');
+    }
+    this.proxy_callback_host = options.proxy_callback_host;
+    if (!this.proxy_callback_host) {
+        throw new Error('Option `proxy_callback_host` is required because you specified `proxy_server`');
+    }
+    //// Optional
+    this.proxy_server_port = options.proxy_server_port || 0;
+    this.proxy_callback_port = options.proxy_callback_port || 80443
+    
+    this.startProxyServer(this.proxy_server_key, this.proxy_server_cert, this.proxy_callback_host, this.proxy_callback_port, this.proxy_server_port);
+  }
+
 };
 
 
@@ -79,30 +135,45 @@ CAS.version = '0.0.4';
  * @param {object} res
  *      HTTP response object
  * @param {function} callback
- *      Success callback: function(err, status, username, attributes) { ... }
+ *      callback(err, status, username, attributes)
+ * @param {String} service
+ *      (optional) The URL of the service/page that is requesting 
+ *      authentication. Default is to extract this automatically from
+ *      the `req` object.
  */
-CAS.prototype.authenticate = function(req, res, callback)
+CAS.prototype.authenticate = function(req, res, callback, service)
 {
     var casURL = 'https://' + this.hostname + ':' + this.port + this.base_path;
-    var ticket = req.param('ticket');
+    var reqURL = url.parse(req.url, true);
     
-    // Set the return URL automatically if it wasn't manually provided
-    if (!this.service) {
-        // Get the URL of the current page
-        this.service = 'http://' + req.headers['host'] + req.url;
+    // Try to extract the CAS ticket from the URL
+    var ticket = reqURL.query['ticket'];
+
+    // Set the service URL automatically if it wasn't manually provided
+    if (!service) {
+        // Get the URL of the current page, minus the 'ticket'
+        delete reqURL.query['ticket'];
+        service = url.format({
+            protocol: req.protocol || 'http',
+            host: req.headers['host'],
+            pathname: reqURL.pathname,
+            query: reqURL.query
+        });
     }
     
     // No ticket, so we haven't been sent to the CAS server yet
     if (!ticket) {
         // redirect to CAS server now
-        res.redirect(casURL + '/login?service=' + encodeURIComponent(this.service));
+        var redirectURL = casURL + '/login?service=' + encodeURIComponent(service);
+        res.writeHead(307, {'Location': redirectURL});
+        res.write('<a href="' + redirectURL + '">CAS login</a>');
+        res.end();
     }
 
     // We have a ticket! 
     else {
-        this.tickets['ST'] = ticket;
         // Validate it with the CAS server now
-        this.validate(ticket, callback);
+        this.validate(ticket, callback, service);
     }
 };
 
@@ -137,43 +208,73 @@ CAS.prototype.logout = function(req, res, returnUrl, doRedirect)
         logout_path = '/logout';
     }
     
-    var casURL = 'https://' + this.hostname + ':' + this.port + this.base_path;
-    res.redirect(casURL + logout_path);
+    var redirectURL = 'https://' + this.hostname + ':' + this.port + this.base_path + logout_path;
+    res.writeHead(307, {'Location' : redirectURL});
+    res.write('<a href="' + redirectURL + '">CAS logout</a>');
+    res.end();
 }
 
 
 
 /**
  * Attempt to validate a given ticket with the CAS server.
- * `callback` is called with (err, auth_status, username, attributes)
+ * `callback` is called with (err, auth_status, username, extended)
  *
  * @param {String} ticket
- * @param {Function} callback 
- * @param {Boolean} renew (optional)
+ *     Either a service ticket (ST) or a proxy ticket (PT)
+ * @param {Function} callback
+ *     callback(err, auth_status, username, extended)
+ * @param {String} service
+ *     The URL of the service requesting authentication. Optional if
+ *     the `service` option was specified during initialization.
+ * @param {Boolean} renew 
+ *     (optional) Set this to TRUE to force the CAS server to request
+ *     credentials from the user even if they had already done so
+ *     recently.
  * @api public
  */
-CAS.prototype.validate = function(ticket, callback, renew) {
+CAS.prototype.validate = function(ticket, callback, service, renew) {
   // Use different CAS path depending on version
   var validate_path;
+  var pgtURL;
   if (this.version < 2.0) {
     // CAS 1.0
     validate_path = 'validate';
   } else {
     // CAS 2.0
-    validate_path = 'serviceValidate';
+    if (ticket.indexOf('PT-') == 0) {
+      validate_path = 'proxyValidate';
+      pgtURL = undefined;
+    } else {
+      validate_path = 'serviceValidate';
+      pgtURL = this.pgt_url;
+    }
+  }
+  
+  // Service URL can be specified in the function call, or during
+  // initialization.
+  var service_url = service || this.service;
+  if (!service_url) {
+    throw new Error('Required CAS option `service` missing.');
   }
 
-  if (!this.service) {
-    throw new Error('Required CAS option `service` missing.');
+  var query = {
+    'ticket': ticket,
+    'service': service_url
+  };
+  if (renew) {
+    query['renew'] = 1;
+  }
+  if (pgtURL) {
+    query['pgtUrl'] = pgtURL;
   }
 
   var req = https.get({
     host: this.hostname,
     port: this.port,
     path: url.format({
-      "pathname": this.base_path+'/'+validate_path,
-      "query": {ticket: ticket, service: this.service},
-      "renew": renew
+      pathname: this.base_path+'/'+validate_path,
+      query: query
     })
   }, function(res) {
     // Handle server errors
@@ -202,10 +303,10 @@ CAS.prototype.validate = function(ticket, callback, renew) {
           }
         }
         // Format was not correct, error
-        callback({message: 'Bad response format.'});
+        callback(new Error('Bad response format.'));
       } 
       
-      // CAS 2.0 (XML response, and optional attributes)
+      // CAS 2.0 (XML response, and extended attributes)
       else {
         // Use jsdom to parse the XML repsonse.
         // ( Note:
@@ -213,151 +314,63 @@ CAS.prototype.validate = function(ticket, callback, renew) {
         //     And node names here are case insensitive. Hence attribute
         //     names will also be case insensitive.
         // )
-        //response = response.replace(/<cas:/, '<').replace(/<\/cas:/, '</');
         jsdom.env(response, function(err, window) {
             if (err) {
-                callback({message: 'jsdom could not parse response' + response});
+                callback(new Error('jsdom could not parse response: ' + response));
                 return;
             } else {
                 // Check for auth success
-                var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess');
-                elemSuccess = elemSuccess[0];
+                var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess')[0];
                 if (elemSuccess) {
                     var elemUser = elemSuccess.getElementsByTagName('cas:user')[0];
                     if (!elemUser) {
-                        //  no "user"??
-                        callback({'message': "No username?"}, false);
-                        return;
-                    } else {
-                        // Success
-                        var username = elemUser.textContent;
-
-                        var attributes = {};
-                        // Look for any optional attributes
-                        var elemAttribute = window.document.getElementsByTagName('cas:attributes')[0];
-                        if (elemAttribute && elemAttribute.hasChildNodes()) {
-                            // "Jasig Style" Attributes:
-                            // 
-                            //  <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-                            //      <cas:authenticationSuccess>
-                            //          <cas:user>jsmith</cas:user>
-                            //          <cas:attributes>
-                            //              <cas:attraStyle>RubyCAS</cas:attraStyle>
-                            //              <cas:surname>Smith</cas:surname>
-                            //              <cas:givenName>John</cas:givenName>
-                            //              <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
-                            //              <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
-                            //          </cas:attributes>
-                            //          <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
-                            //      </cas:authenticationSuccess>
-                            //  </cas:serviceResponse>
-                            //
-                            for (var i=0; i<elemAttribute.childNodes.length; i++) {
-                                var node = elemAttribute.childNodes[i];
-                                var attrName = node.nodeName.toLowerCase().replace(/cas:/, '');
-                                var attrValue = node.textContent;
-                                if (!attributes[attrName]) {
-                                    attributes[attrName] = [attrValue];
-                                } else {
-                                    attributes[attrName].push(attrValue);
-                                }
-                            }
-                        }
-                        
-                        else {
-                            // "RubyCAS Style" attributes
-                            // 
-                            //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-                            //        <cas:authenticationSuccess>
-                            //            <cas:user>jsmith</cas:user>
-                            //                      
-                            //            <cas:attraStyle>RubyCAS</cas:attraStyle>
-                            //            <cas:surname>Smith</cas:surname>
-                            //            <cas:givenName>John</cas:givenName>
-                            //            <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
-                            //            <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
-                            //                      
-                            //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
-                            //        </cas:authenticationSuccess>
-                            //    </cas:serviceResponse>
-                            // 
-                            for (var i=0; i<elemSuccess.childNodes.length; i++) {
-                                var node = elemSuccess.childNodes[i];
-                                var tagName = node.nodeName.toLowerCase().replace(/cas:/, '');
-                                switch (tagName) {
-                                    case 'user':
-                                    case 'proxies':
-                                    case 'proxygrantingticket':
-                                        // these are not CAS attributes
-                                        break;
-                                    default:
-                                        var attrName = tagName;
-                                        var attrValue = node.textContent;
-                                        if (attrValue != '') {
-                                            if (!attributes[attrName]) {
-                                                attributes[attrName] = [attrValue];
-                                            } else {
-                                                attributes[attrName].push(attrValue);
-                                            }
-                                        }
-                                        break;
-                                }
-                            }
-                        }
-                        
-                        if (attributes == {}) {
-                            // "Name-Value" attributes.
-                            // 
-                            // Attribute format from this mailing list thread:
-                            // http://jasig.275507.n4.nabble.com/CAS-attributes-and-how-they-appear-in-the-CAS-response-td264272.html
-                            // Note: This is a less widely used format, but in use by at least two institutions.
-                            // 
-                            //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-                            //        <cas:authenticationSuccess>
-                            //            <cas:user>jsmith</cas:user>
-                            //                      
-                            //            <cas:attribute name='attraStyle' value='Name-Value' />
-                            //            <cas:attribute name='surname' value='Smith' />
-                            //            <cas:attribute name='givenName' value='John' />
-                            //            <cas:attribute name='memberOf' value='CN=Staff,OU=Groups,DC=example,DC=edu' />
-                            //            <cas:attribute name='memberOf' value='CN=Spanish Department,OU=Departments,...' />
-                            //                      
-                            //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
-                            //        </cas:authenticationSuccess>
-                            //    </cas:serviceResponse>
-                            //
-                            var nodes = elemSuccess.getElementsByTagName('cas:attribute');
-                            if (nodes && nodes.length) {
-                                for (var i=0; i<nodes.length; i++) {
-                                    var attrName = nodes[i].getAttribute('name');
-                                    var attrValue = nodes[i].getAttribute('value');
-                                    if (!attributes[attrName]) {
-                                        attributes[attrName] = [attrValue];
-                                    } else {
-                                        attributes[attrName].push(attrValue);
-                                    }
-                                }
-                            }
-                        }
-                        
-                        //console.log(attributes);
-                        callback(undefined, true, username, attributes);
+                        //  This should never happen
+                        callback(new Error("No username?"), false);
                         return;
                     }
+
+                    // Got username
+                    var username = elemUser.textContent;
+                    
+                    // Look for optional proxy granting ticket
+                    var pgtIOU;
+                    var elemPGT = elemSuccess.getElementsByTagName('cas:proxyGrantingTicket')[0];
+                    if (elemPGT) {
+                        pgtIOU = elemPGT.textContent;
+                    }
+                    
+                    // Look for optional proxies
+                    var proxies = [];
+                    var elemProxies = elemSuccess.getElementsByTagName('cas:proxies');
+                    for (var i=0; i<elemProxies.length; i++) {
+                        proxies.push( elemProxies[i].textContent );
+                    }
+
+                    // Look for optional attributes
+                    var attributes = parseAttributes(elemSuccess);
+                    
+                    callback(undefined, true, username, {
+                        'username': username,
+                        'attributes': attributes,
+                        'PGTIOU': pgtIOU,
+                        'proxies': proxies
+                    });
+                    return;
                 } // end if auth success
 
                 // Check for correctly formatted auth failure message
                 var elemFailure = window.document.getElementsByTagName('cas:authenticationFailure')[0];
                 if (elemFailure) {
                     var code = elemFailure.getAttribute('code');
-                    var message = 'Login failed: ';
+                    var message = 'Validation failed [' + code +']: ';
                     message += elemFailure.textContent;
-                    callback({ 'code': code, 'message': message }, false);
+                    callback(new Error(message), false);
                     return;
                 }
 
                 // The response was not in any expected format, error
-                callback({message: 'Bad response format.'});
+                callback(new Error('Bad response format.'));
+                console.error(response);
                 return;
             }
         });
@@ -367,3 +380,378 @@ CAS.prototype.validate = function(ticket, callback, renew) {
     });
   });
 };
+
+
+/**
+ * Send a PGT to the CAS server, and get a PT in return.
+ * Used internally by the proxy server.
+ *
+ * @param {string} pgt
+ *      Proxy granting ticket
+ * @param {function} callback
+ *      callback(err, pt)
+ */
+CAS.prototype.getProxyTicket = function(pgt, targetService, callback) {
+    var req = https.get({
+        host: this.hostname,
+        port: this.port,
+        path: url.format({
+            'pathname': this.base_path + '/proxy',
+            'query': { 
+                'targetService': targetService,
+                'pgt': pgt
+            }
+        })
+    }, function(res) {
+        // Handle server errors
+        res.on('error', function(e) {
+            callback(e);
+        });
+        
+        // Read result
+        res.setEncoding('utf8');
+        var response = '';
+        res.on('data', function(chunk) {
+            response += chunk;
+        });
+        res.on('end', function() {
+            // Use jsdom to parse the XML response
+            jsdom.env(response, function(err, window) {
+                if (err) {
+                    callback(new Error("jsdom could not parse response: " + response));
+                    return;
+                }
+                // Got the proxy ticket
+                var elemTicket = window.document.getElementsByTagName('cas:proxyTicket')[0];
+                if (elemTicket) {
+                    var proxyTicket = elemTicket.textContent;
+                    callback(undefined, proxyTicket);
+                    return;
+                }
+                // Got a proxy failure
+                var elemFailure = window.document.getElementsByTagName('cas:proxyFailure')[0];
+                if (elemFailure) {
+                    var code = elemFailure.getAttribute('code');
+                    var message = 'Proxy failure [' + code + ']: ';
+                    message += elemFailure.textContent;
+                    callback(new Error(message));
+                    return;
+                }
+                // Unexpected response
+                callback(new Error("Bad response format: " + response));
+                return;
+            });
+        });
+    });
+}
+
+
+/**
+ * Start a local proxy server.
+ * 
+ * This is a local HTTPS server that listens for incoming connections from 
+ * the CAS server. Any PGTs received from the CAS server will be stored
+ * in `this.pgtStore`.
+ *
+ * This is optionally also a proxy server that listens for outgoing proxy 
+ * requests from clients that already have a PGTIOU. In addition to the 
+ * normal HTTP information, the client must also supply these two headers 
+ * in the request:
+ *    cas-proxy-pgtiou
+ *    cas-proxy-targeturl
+ *
+ * For this to work, the local machine and the CAS server must be able to 
+ * access each other on the network.
+ *
+ * @param {string/buffer} key
+ *    The SSL private key
+ * @param {string/buffer} cert
+ *    The SSL certificate
+ * @param {string} callbackHost
+ *    The publicly accessible hostname for the callback server.
+ * @param {int} callbackPort
+ *    The port number to listen on for incoming CAS PGT messages.
+ * @param {int} proxyPort
+ *    The port number to listen on for outgoing proxied requests.
+ *    Omit this to disable the proxy server and only allow
+ *    internal requests via CAS.proxiedRequest().
+ */
+CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort, proxyPort) {
+    var serverOptions = {
+        'key': key,
+        'cert': cert
+    };
+    var self = this;
+    
+    // This is the pgtURL that will be sent to the CAS server during a
+    // validation request.
+    this.pgt_url = 'https://' + callbackHost + ':' + callbackPort + '/';
+    
+    // PGT callback server that listens for incoming connections from
+    // the CAS server.
+    var pgtServer = https.createServer(serverOptions);
+    pgtServer.addListener("request", function(req, res) {
+        res.writeHead(200, {'Content-Type': 'text/plain'});
+        res.end();
+        // Save the PGT ticket into the memory store
+        var reqURL = url.parse(req.url, true);
+        var pgtIOU = reqURL.query['pgtIou'];
+        var pgtID = reqURL.query['pgtId'];
+        if (pgtIOU && pgtID) {
+            self.pgtStore[ pgtIOU[1] ] = pgtID[1];
+        } else {
+            console.error('Got unrecognized request via PGT callback:');
+            console.error(req.method + ' ' + req.url);
+        }
+    });
+    pgtServer.listen(callbackPort);
+    
+    // Proxy server that listens for local connections and forwards them to 
+    // the target service. Disabled by default.
+    if (proxyPort) {
+        console.log('proxy on port ' + proxyPort);
+        var proxyServer = https.createServer(serverOptions);
+        proxyServer.addListener("request", function(req, res) {
+            console.log('got request');
+            // Use "cas-proxy-..." headers to obtain information about the 
+            // requested target service.
+            try {
+                var pgtIOU = req.headers['cas-proxy-pgtiou'];
+                if (!pgtIOU) {
+                    throw 'Header "cas-proxy-pgtiou" was not found';
+                }
+                if (!this.pgtStore[pgtIOU]) {
+                    throw 'Invalid "cas-proxy-pgtiou" was given';
+                }
+                var targetURL = req.headers['cas-proxy-targeturl'];
+                if (!targetURL) {
+                    throw 'Header "cas-proxy-targeturl" was not found';
+                }
+                targetURL = url.parse(targetURL, true);
+                var targetHost = targetURL.host;
+                if (!targetHost) {
+                    throw 'Invalid "cas-proxy-targeturl" was given';
+                }
+                var targetProtocol = targetURL.protocol || 'http';
+                var targetPort = targetURL.port || (targetProtocol == 'https' ? 443 : 80);
+                var targetPathname = targetURL.pathname || '/';
+            } catch (e) {
+                console.error('Wrong headers');
+                res.writeHead(500, {'Content-Type': 'text/plain'});
+                res.write('4001 - CAS Proxy Error\n');
+                res.write(e);
+                res.end();
+                return;
+            }
+            
+            // The headers are okay. Next begin the proxied request.
+            var targetOptions = {
+                method: req.method,
+                headers: req.headers,
+                protocol: targetProtocol,
+                host: targetHost,
+                port: targetPort,
+                pathname: pargetPathname
+            };
+            this.proxiedRequest(pgtIOU, targetOptions, function(err, targetReq, targetRes) {
+                if (err) {
+                    res.writeHead(500, {'Content-Type': 'text/plain'});
+                    res.write('500 - CAS Proxy Error\n');
+                    res.write(err.message);
+                    res.end();
+                    return;
+                }
+            
+                // Mirror requester's data to the target
+                req.on('data', function(chunk) {
+                    targetReq.write(chunk);
+                });
+                req.on('end', function() {
+                    targetReq.end();
+                });
+            
+                // Mirror target's response headers back to requester
+                res.writeHead(targetRes.statusCode, targetRes.headers);
+            
+                // Mirror target's data back to the requester
+                targetRes.on('data', function(chunk) {
+                    res.write(chunk);
+                });
+                targetRes.on('end', function() {
+                    res.end();
+                });
+            });
+        });
+        proxyServer.listen(proxyPort);
+    }
+}
+
+
+/**
+ * Create a CAS proxied HTTP/HTTPS request.
+ * The CAS proxy ticket (PT) will automatically be added to the target 
+ * service's query.
+ *
+ * @param {String} pgtIOU
+ *     This should have been obtained during the initial CAS login with
+ *     the validate() function.
+ * @param {Object} options
+ *     Same as the options passed in to http.request(). This is where you 
+ *     specify the service URL you are requesting.
+ * @param {function} callback
+ *     callback(err, req, res)
+ */
+CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
+    // Fetch the PGT using the PGTIOU
+    var pgt = this.pgtStore[pgtIOU];
+    if (!pgt) {
+        callback(new Error('Invalid PGTIOU supplied'));
+    }
+    
+    var targetService = options.path;
+    if (typeof options.path != 'string') {
+        targetService = url.format(options.path);
+    }
+
+    this.getProxyTicket(pgt, targetService, function(err, pt) {
+        if (err) {
+            callback(err);
+        }
+        
+        // Add the proxy ticket to the target service's query string
+        if (typeof options.path == 'string') {
+            options.path = url.parse(path, true);
+        }
+        options.path.query['ticket'] = pt;
+        
+        // Request the target service
+        var req = http.request(options, function(res) {
+            callback(undefined, req, res);
+        });
+    });
+}
+
+
+/**
+ * Parse a cas:authenticationSuccess XML node for CAS attributes.
+ * Supports Jasig style, RubyCAS style, and Name-Value.
+ *
+ * @param {object} elemSuccess
+ *     DOM node
+ * @return {object}
+ *     {
+ *         attr1: [ attr1-val1, attr1-val2, ... ],
+ *         attr2: [ attr2-val1, attr2-val2, ... ],
+ *         ...
+ *     }
+ */
+var parseAttributes = function(elemSuccess) {
+    var attributes = {};
+    var elemAttribute = elemSuccess.getElementsByTagName('cas:attributes')[0];
+    if (elemAttribute && elemAttribute.hasChildNodes()) {
+        // "Jasig Style" Attributes:
+        // 
+        //  <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+        //      <cas:authenticationSuccess>
+        //          <cas:user>jsmith</cas:user>
+        //          <cas:attributes>
+        //              <cas:attraStyle>RubyCAS</cas:attraStyle>
+        //              <cas:surname>Smith</cas:surname>
+        //              <cas:givenName>John</cas:givenName>
+        //              <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        //              <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
+        //          </cas:attributes>
+        //          <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
+        //      </cas:authenticationSuccess>
+        //  </cas:serviceResponse>
+        //
+        for (var i=0; i<elemAttribute.childNodes.length; i++) {
+            var node = elemAttribute.childNodes[i];
+            var attrName = node.nodeName.toLowerCase().replace(/cas:/, '');
+            var attrValue = node.textContent;
+            if (!attributes[attrName]) {
+                attributes[attrName] = [attrValue];
+            } else {
+                attributes[attrName].push(attrValue);
+            }
+        }
+    }
+    
+    else {
+        // "RubyCAS Style" attributes
+        // 
+        //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+        //        <cas:authenticationSuccess>
+        //            <cas:user>jsmith</cas:user>
+        //                      
+        //            <cas:attraStyle>RubyCAS</cas:attraStyle>
+        //            <cas:surname>Smith</cas:surname>
+        //            <cas:givenName>John</cas:givenName>
+        //            <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        //            <cas:memberOf>CN=Spanish Department,OU=Departments,...</cas:memberOf>
+        //                      
+        //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2...</cas:proxyGrantingTicket>
+        //        </cas:authenticationSuccess>
+        //    </cas:serviceResponse>
+        // 
+        for (var i=0; i<elemSuccess.childNodes.length; i++) {
+            var node = elemSuccess.childNodes[i];
+            var tagName = node.nodeName.toLowerCase().replace(/cas:/, '');
+            switch (tagName) {
+                case 'user':
+                case 'proxies':
+                case 'proxygrantingticket':
+                    // these are not CAS attributes
+                    break;
+                default:
+                    var attrName = tagName;
+                    var attrValue = node.textContent;
+                    if (attrValue != '') {
+                        if (!attributes[attrName]) {
+                            attributes[attrName] = [attrValue];
+                        } else {
+                            attributes[attrName].push(attrValue);
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+    
+    if (attributes == {}) {
+        // "Name-Value" attributes.
+        // 
+        // Attribute format from this mailing list thread:
+        // http://jasig.275507.n4.nabble.com/CAS-attributes-and-how-they-appear-in-the-CAS-response-td264272.html
+        // Note: This is a less widely used format, but in use by at least two institutions.
+        // 
+        //    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+        //        <cas:authenticationSuccess>
+        //            <cas:user>jsmith</cas:user>
+        //                      
+        //            <cas:attribute name='attraStyle' value='Name-Value' />
+        //            <cas:attribute name='surname' value='Smith' />
+        //            <cas:attribute name='givenName' value='John' />
+        //            <cas:attribute name='memberOf' value='CN=Staff,OU=Groups,DC=example,DC=edu' />
+        //            <cas:attribute name='memberOf' value='CN=Spanish Department,OU=Departments,...' />
+        //                      
+        //            <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
+        //        </cas:authenticationSuccess>
+        //    </cas:serviceResponse>
+        //
+        var nodes = elemSuccess.getElementsByTagName('cas:attribute');
+        if (nodes && nodes.length) {
+            for (var i=0; i<nodes.length; i++) {
+                var attrName = nodes[i].getAttribute('name');
+                var attrValue = nodes[i].getAttribute('value');
+                if (!attributes[attrName]) {
+                    attributes[attrName] = [attrValue];
+                } else {
+                    attributes[attrName].push(attrValue);
+                }
+            }
+        }
+    }
+    
+    return attributes;
+}

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -68,6 +68,8 @@ var jsdom = require('jsdom');
  *       'proxy_server_cert':
  *           A string value of your SSL certificate. 
  *           Required only if you used `proxy_server`.
+ *       'proxy_server_ca':
+ *           (optional) An array of SSL CA and Intermediate CA certificates.
  *
  *       'sso_servers':
  *           An array of IP addresses of servers that we will accept
@@ -153,8 +155,9 @@ var CAS = module.exports = function CAS(options)
     //// Optional
     this.proxy_server_port = options.proxy_server_port || 0;
     this.proxy_callback_port = options.proxy_callback_port || 80443
+    this.proxy_server_ca = options.proxy_server_ca || [];
     
-    this.startProxyServer(this.proxy_server_key, this.proxy_server_cert, this.proxy_callback_host, this.proxy_callback_port, this.proxy_server_port);
+    this.startProxyServer(this.proxy_server_key, this.proxy_server_cert, this.proxy_server_ca, this.proxy_callback_host, this.proxy_callback_port, this.proxy_server_port);
   }
 
 };
@@ -649,6 +652,8 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
  *    The SSL private key
  * @param {String/Buffer} cert
  *    The SSL certificate
+ * @param {Array} ca
+ *    The CA Bundle for the SSL certificate
  * @param {String} callbackHost
  *    The publicly accessible hostname for the callback server.
  * @param {Integer} callbackPort
@@ -659,11 +664,12 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
  *    internal requests via CAS.proxiedRequest().
  * @api public
  */
-CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort, proxyPort) 
+CAS.prototype.startProxyServer = function(key, cert, ca, callbackHost, callbackPort, proxyPort) 
 {
     var serverOptions = {
         'key': key,
-        'cert': cert
+        'cert': cert,
+        'ca': ca
     };
     var self = this;
     

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -135,7 +135,7 @@ CAS.version = '0.0.4';
  * @param {object} res
  *      HTTP response object
  * @param {function} callback
- *      callback(err, status, username, attributes)
+ *      callback(err, status, username, extended)
  * @param {String} service
  *      (optional) The URL of the service/page that is requesting 
  *      authentication. Default is to extract this automatically from
@@ -159,6 +159,7 @@ CAS.prototype.authenticate = function(req, res, callback, service)
             pathname: reqURL.pathname,
             query: reqURL.query
         });
+        //console.log('authenticate() -- derived service: ' + service);
     }
     
     // No ticket, so we haven't been sent to the CAS server yet
@@ -242,12 +243,12 @@ CAS.prototype.validate = function(ticket, callback, service, renew) {
     validate_path = 'validate';
   } else {
     // CAS 2.0
+    pgtURL = this.pgt_url;
     if (ticket.indexOf('PT-') == 0) {
       validate_path = 'proxyValidate';
-      pgtURL = undefined;
     } else {
-      validate_path = 'serviceValidate';
-      pgtURL = this.pgt_url;
+      //validate_path = 'serviceValidate';
+      validate_path = 'proxyValidate';
     }
   }
   
@@ -268,14 +269,17 @@ CAS.prototype.validate = function(ticket, callback, service, renew) {
   if (pgtURL) {
     query['pgtUrl'] = pgtURL;
   }
+  
+  var queryPath = url.format({
+      pathname: this.base_path+'/'+validate_path,
+      query: query
+    });
+  //console.log('CAS validate path: ' + queryPath);
 
   var req = https.get({
     host: this.hostname,
     port: this.port,
-    path: url.format({
-      pathname: this.base_path+'/'+validate_path,
-      query: query
-    })
+    path: queryPath
   }, function(res) {
     // Handle server errors
     res.on('error', function(e) {
@@ -318,65 +322,68 @@ CAS.prototype.validate = function(ticket, callback, service, renew) {
             if (err) {
                 callback(new Error('jsdom could not parse response: ' + response));
                 return;
-            } else {
-                // Check for auth success
-                var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess')[0];
-                if (elemSuccess) {
-                    var elemUser = elemSuccess.getElementsByTagName('cas:user')[0];
-                    if (!elemUser) {
-                        //  This should never happen
-                        callback(new Error("No username?"), false);
-                        return;
-                    }
-
-                    // Got username
-                    var username = elemUser.textContent;
-                    
-                    // Look for optional proxy granting ticket
-                    var pgtIOU;
-                    var elemPGT = elemSuccess.getElementsByTagName('cas:proxyGrantingTicket')[0];
-                    if (elemPGT) {
-                        pgtIOU = elemPGT.textContent;
-                    }
-                    
-                    // Look for optional proxies
-                    var proxies = [];
-                    var elemProxies = elemSuccess.getElementsByTagName('cas:proxies');
-                    for (var i=0; i<elemProxies.length; i++) {
-                        proxies.push( elemProxies[i].textContent );
-                    }
-
-                    // Look for optional attributes
-                    var attributes = parseAttributes(elemSuccess);
-                    
-                    callback(undefined, true, username, {
-                        'username': username,
-                        'attributes': attributes,
-                        'PGTIOU': pgtIOU,
-                        'proxies': proxies
-                    });
-                    return;
-                } // end if auth success
-
-                // Check for correctly formatted auth failure message
-                var elemFailure = window.document.getElementsByTagName('cas:authenticationFailure')[0];
-                if (elemFailure) {
-                    var code = elemFailure.getAttribute('code');
-                    var message = 'Validation failed [' + code +']: ';
-                    message += elemFailure.textContent;
-                    callback(new Error(message), false);
+            } 
+            
+            // Check for auth success
+            var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess')[0];
+            if (elemSuccess) {
+                var elemUser = elemSuccess.getElementsByTagName('cas:user')[0];
+                if (!elemUser) {
+                    //  This should never happen
+                    callback(new Error("No username?"), false);
                     return;
                 }
 
-                // The response was not in any expected format, error
-                callback(new Error('Bad response format.'));
-                console.error(response);
+                // Got username
+                var username = elemUser.textContent;
+                
+                // Look for optional proxy granting ticket
+                var pgtIOU;
+                var elemPGT = elemSuccess.getElementsByTagName('cas:proxyGrantingTicket')[0];
+                if (elemPGT) {
+                    pgtIOU = elemPGT.textContent;
+                }
+                
+                // Look for optional proxies
+                var proxies = [];
+                var elemProxies = elemSuccess.getElementsByTagName('cas:proxies');
+                for (var i=0; i<elemProxies.length; i++) {
+                    var thisProxy = elemProxies[i].textContent;
+                    // trim whitespace
+                    thisProxy = thisProxy
+                        .replace(/^\s+/, '', thisProxy)
+                        .replace(/\s+$/, '', thisProxy);
+                    proxies.push(thisProxy);
+                }
+
+                // Look for optional attributes
+                var attributes = parseAttributes(elemSuccess);
+                
+                callback(undefined, true, username, {
+                    'username': username,
+                    'attributes': attributes,
+                    'PGTIOU': pgtIOU,
+                    'proxies': proxies
+                });
+                return;
+            } // end if auth success
+
+            // Check for correctly formatted auth failure message
+            var elemFailure = window.document.getElementsByTagName('cas:authenticationFailure')[0];
+            if (elemFailure) {
+                var code = elemFailure.getAttribute('code');
+                var message = 'Validation failed [' + code +']: ';
+                message += elemFailure.textContent;
+                callback(new Error(message), false);
                 return;
             }
-        });
-        
-      };
 
+            // The response was not in any expected format, error
+            callback(new Error('Bad response format.'));
+            console.error(response);
+            return;
+        });
+      };
     });
   });
 };
@@ -490,6 +497,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     // PGT callback server that listens for incoming connections from
     // the CAS server.
     var pgtServer = https.createServer(serverOptions);
+    console.log('Starting PGT callback server');
     pgtServer.addListener("request", function(req, res) {
         res.writeHead(200, {'Content-Type': 'text/plain'});
         res.end();
@@ -498,10 +506,10 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
         var pgtIOU = reqURL.query['pgtIou'];
         var pgtID = reqURL.query['pgtId'];
         if (pgtIOU && pgtID) {
-            self.pgtStore[ pgtIOU[1] ] = pgtID[1];
+            self.pgtStore[ pgtIOU ] = pgtID;
+            //console.log('Callback -- got PGT: ' + pgtID);
         } else {
-            console.error('Got unrecognized request via PGT callback:');
-            console.error(req.method + ' ' + req.url);
+            //console.error('Callback -- Got unrecognized request:' + req.method + ' ' + req.url);
         }
     });
     pgtServer.listen(callbackPort);
@@ -509,10 +517,9 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     // Proxy server that listens for local connections and forwards them to 
     // the target service. Disabled by default.
     if (proxyPort) {
-        console.log('proxy on port ' + proxyPort);
         var proxyServer = https.createServer(serverOptions);
+        console.log('Starting CAS proxy server');
         proxyServer.addListener("request", function(req, res) {
-            console.log('got request');
             // Use "cas-proxy-..." headers to obtain information about the 
             // requested target service.
             try {
@@ -520,40 +527,32 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
                 if (!pgtIOU) {
                     throw 'Header "cas-proxy-pgtiou" was not found';
                 }
-                if (!this.pgtStore[pgtIOU]) {
+                if (!self.pgtStore[pgtIOU]) {
                     throw 'Invalid "cas-proxy-pgtiou" was given';
                 }
                 var targetURL = req.headers['cas-proxy-targeturl'];
                 if (!targetURL) {
                     throw 'Header "cas-proxy-targeturl" was not found';
                 }
-                targetURL = url.parse(targetURL, true);
-                var targetHost = targetURL.host;
-                if (!targetHost) {
+                targetOptions = url.parse(targetURL, true);
+                if (!targetOptions.hostname) {
                     throw 'Invalid "cas-proxy-targeturl" was given';
                 }
-                var targetProtocol = targetURL.protocol || 'http';
-                var targetPort = targetURL.port || (targetProtocol == 'https' ? 443 : 80);
-                var targetPathname = targetURL.pathname || '/';
             } catch (e) {
-                console.error('Wrong headers');
-                res.writeHead(500, {'Content-Type': 'text/plain'});
-                res.write('4001 - CAS Proxy Error\n');
-                res.write(e);
+                res.writeHead(400, {'Content-Type': 'text/plain'});
+                res.write('400 - CAS Proxy Error\n');
+                if (typeof e == 'string') {
+                    res.write(e);
+                } else {
+                    res.write(e.message);
+                }
                 res.end();
                 return;
             }
             
             // The headers are okay. Next begin the proxied request.
-            var targetOptions = {
-                method: req.method,
-                headers: req.headers,
-                protocol: targetProtocol,
-                host: targetHost,
-                port: targetPort,
-                pathname: pargetPathname
-            };
-            this.proxiedRequest(pgtIOU, targetOptions, function(err, targetReq, targetRes) {
+            targetOptions.method = req.method || 'GET';
+            self.proxiedRequest(pgtIOU, targetOptions, function(err, targetReq, targetRes) {
                 if (err) {
                     res.writeHead(500, {'Content-Type': 'text/plain'});
                     res.write('500 - CAS Proxy Error\n');
@@ -602,32 +601,51 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
  *     callback(err, req, res)
  */
 CAS.prototype.proxiedRequest = function(pgtIOU, options, callback) {
-    // Fetch the PGT using the PGTIOU
+    // Look up the PGT using the PGTIOU
     var pgt = this.pgtStore[pgtIOU];
     if (!pgt) {
         callback(new Error('Invalid PGTIOU supplied'));
     }
     
-    var targetService = options.path;
-    if (typeof options.path != 'string') {
-        targetService = url.format(options.path);
-    }
-
+    var targetService = url.format(options);
+    //console.log('Proxied Request -- targetService: ' + targetService);
+    
     this.getProxyTicket(pgt, targetService, function(err, pt) {
         if (err) {
             callback(err);
+            return;
         }
+        //console.log('Proxied Request -- got PT: ' + pt);
         
         // Add the proxy ticket to the target service's query string
-        if (typeof options.path == 'string') {
-            options.path = url.parse(path, true);
+        var path = options.path || targetService.replace(/^https?:\/\/[^\/]+/, '');
+        if (path.indexOf('&') >= 0) {
+            options.path = path + '&ticket=' + pt;
+        } else {
+            options.path = path + '?ticket=' + pt;
         }
-        options.path.query['ticket'] = pt;
+        delete options.pathname;
+        delete options.search;
+        delete options.href;
+        delete options.query;
+        options.agent = false;
         
         // Request the target service
-        var req = http.request(options, function(res) {
-            callback(undefined, req, res);
-        });
+        var serviceObj;
+        if (options.options == 'https:') {
+            serviceObj = https;
+        } else {
+            serviceObj = http;
+        }
+        try {
+            var req = serviceObj.get(options, function(res) {
+                callback(undefined, req, res);
+            });
+        }
+        catch (e) {
+            callback(e);
+        }
+        
     });
 }
 

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -123,7 +123,7 @@ var CAS = module.exports = function CAS(options)
   // or as a client contacting the external PGT URL.
   this.ssl_cert = options.ssl_cert || null;
   this.ssl_key = options.ssl_key || null;
-  this.ssl_ca = options.ssl_ca || [];
+  this.ssl_ca = options.ssl_ca || null;
   
   // Setting this to false will allow cause bad SSL certificates to still
   // be accepted. Use only for testing.

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -88,7 +88,7 @@ var jsdom = require('jsdom');
  * @api public
  */
 var CAS = module.exports = function CAS(options) 
-{  
+{
   options = options || {};
   
   // Backwards compatibility for old option names
@@ -124,6 +124,10 @@ var CAS = module.exports = function CAS(options)
   this.ssl_cert = options.ssl_cert || null;
   this.ssl_key = options.ssl_key || null;
   this.ssl_ca = options.ssl_ca || [];
+  
+  // Setting this to false will allow cause bad SSL certificates to still
+  // be accepted. Use only for testing.
+  this.secureSSL = true;
   
   // Optional single sign out server list
   if (options.sso_servers) {
@@ -399,7 +403,9 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
   var req = https.get({
     host: this.hostname,
     port: this.port,
-    path: queryPath
+    path: queryPath,
+    ca: this.ssl_ca || null,
+    rejectUnauthorized: this.secureSSL
   }, function(res) {
     // Handle server errors
     res.on('error', function(e) {
@@ -506,6 +512,12 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
       };
     });
   });
+  
+  // Connection error with the CAS server
+  req.on('error', function(err) {
+    callback(err);
+    req.abort();
+  });
 };
 
 
@@ -532,6 +544,7 @@ CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
         urlFetchPGT.key = this.ssl_key || null;
         urlFetchPGT.cert = this.ssl_cert || null;
         urlFetchPGT.ca = this.ssl_ca || null;
+        urlFetchPGT.rejectUnauthorized = this.secureSSL;
         
         var req = https.get(urlFetchPGT, function(res) {
             res.on('data', function(chunk) {
@@ -605,6 +618,8 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
             protocol: 'https:',
             hostname: self.hostname,
             port: self.port,
+            ca: self.ssl_ca || null,
+            rejectUnauthorized: self.secureSSL,
             path: url.format({
                 pathname: self.base_path + '/proxy',
                 query: { 

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -17,7 +17,7 @@
 var http = require('http');
 var https = require('https');
 var url = require('url');
-var jsdom = require('jsdom');
+var cheerio = require('cheerio');
 
 
 
@@ -273,21 +273,23 @@ CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
             // not a recognized single signout server
             return next();
         }
-        // This was a signout request. Parse the XML.
-        jsdom.env(req.body['logoutRequest'], function(err, window) {
-            if (!err) {
-                var ticketElem = window.document.getElementsByTagName('samlp:SessionIndex')[0];
-                if (ticketElem) {
-                    // This is the ticket that was issued by CAS when the user
-                    // first logged in. Pass it into the callback so the
-                    // application can use it to delete the user's session.
-                    var ticket = ticketElem.textContent.trim();
-                    return logoutCallback(ticket);
-                }
+        
+        try {
+            // This was a signout request. Parse the XML.
+            var $ = cheerio.load(req.body['logoutRequest']);
+            var ticketElems = $('samlp\\:SessionIndex');
+            if (ticketElems && ticketElems.length > 0) {
+                // This is the ticket that was issued by CAS when the user
+                // first logged in. Pass it into the callback so the
+                // application can use it to delete the user's session.
+                var ticket = ticketElems.first().text().trim();
+                return logoutCallback(ticket);
             }
+        }
+        catch (err) {
             // This was not a valid signout request.
             return next();
-        });
+        }
     }
     else {
         // This was not a signout request. Proceed normally.
@@ -441,74 +443,64 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
       
       // CAS 2.0 (XML response, and extended attributes)
       else {
-        // Use jsdom to parse the XML repsonse.
-        // ( Note:
-        //     It seems jsdom currently does not support XML namespaces.
-        //     And node names here are case insensitive. Hence attribute
-        //     names will also be case insensitive.
-        // )
-        jsdom.env(response, function(err, window) {
-            if (err) {
-                callback(new Error('jsdom could not parse response: ' + response));
-                return;
-            } 
-            
-            // Check for auth success
-            var elemSuccess = window.document.getElementsByTagName('cas:authenticationSuccess')[0];
-            if (elemSuccess) {
-                var elemUser = elemSuccess.getElementsByTagName('cas:user')[0];
-                if (!elemUser) {
-                    //  This should never happen
-                    callback(new Error("No username?"), false);
-                    return;
-                }
-
-                // Got username
-                var username = elemUser.textContent;
-                
-                // Look for optional proxy granting ticket
-                var pgtIOU;
-                var elemPGT = elemSuccess.getElementsByTagName('cas:proxyGrantingTicket')[0];
-                if (elemPGT) {
-                    pgtIOU = elemPGT.textContent;
-                }
-                
-                // Look for optional proxies
-                var proxies = [];
-                var elemProxies = elemSuccess.getElementsByTagName('cas:proxies');
-                for (var i=0; i<elemProxies.length; i++) {
-                    var thisProxy = elemProxies[i].textContent.trim();
-                    proxies.push(thisProxy);
-                }
-
-                // Look for optional attributes
-                var attributes = parseAttributes(elemSuccess);
-                
-                callback(undefined, true, username, {
-                    'username': username,
-                    'attributes': attributes,
-                    'PGTIOU': pgtIOU,
-                    'ticket': ticket,
-                    'proxies': proxies
-                });
-                return;
-            } // end if auth success
-
-            // Check for correctly formatted auth failure message
-            var elemFailure = window.document.getElementsByTagName('cas:authenticationFailure')[0];
-            if (elemFailure) {
-                var code = elemFailure.getAttribute('code');
-                var message = 'Validation failed [' + code +']: ';
-                message += elemFailure.textContent;
-                callback(new Error(message), false);
+        // Use cheerio to parse the XML repsonse.
+        var $ = cheerio.load(response);
+        
+        // Check for auth success
+        var elemSuccess = $('cas\\:authenticationSuccess').first();
+        if (elemSuccess && elemSuccess.length > 0) {
+            var elemUser = elemSuccess.find('cas\\:user').first();
+            if (!elemUser || elemUser.length < 1) {
+                //  This should never happen
+                callback(new Error("No username?"), false);
                 return;
             }
 
-            // The response was not in any expected format, error
-            callback(new Error('Bad response format.'));
-            console.error(response);
+            // Got username
+            var username = elemUser.text();
+            
+            // Look for optional proxy granting ticket
+            var pgtIOU;
+            var elemPGT = elemSuccess.find('cas\\:proxyGrantingTicket').first();
+            if (elemPGT) {
+                pgtIOU = elemPGT.text();
+            }
+            
+            // Look for optional proxies
+            var proxies = [];
+            var elemProxies = elemSuccess.find('cas\\:proxies');
+            for (var i=0; i<elemProxies.length; i++) {
+                var thisProxy = $(elemProxies[i]).text().trim();
+                proxies.push(thisProxy);
+            }
+
+            // Look for optional attributes
+            var attributes = parseAttributes(elemSuccess);
+            
+            callback(undefined, true, username, {
+                'username': username,
+                'attributes': attributes,
+                'PGTIOU': pgtIOU,
+                'ticket': ticket,
+                'proxies': proxies
+            });
             return;
-        });
+        } // end if auth success
+
+        // Check for correctly formatted auth failure message
+        var elemFailure = $('cas\\:authenticationFailure').first();
+        if (elemFailure && elemFailure.length > 0) {
+            var code = elemFailure.attr('code');
+            var message = 'Validation failed [' + code +']: ';
+            message += elemFailure.text();
+            callback(new Error(message), false);
+            return;
+        }
+
+        // The response was not in any expected format, error
+        callback(new Error('Bad response format.'));
+        console.error(response);
+        return;
       };
     });
   });
@@ -643,32 +635,28 @@ CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback)
                 }
             });
             res.on('end', function() {
-                // Use jsdom to parse the XML response
-                jsdom.env(response, function(err, window) {
-                    if (err) {
-                        callback(new Error("Could not parse response: " + response));
-                        return;
-                    }
-                    // Got the proxy ticket
-                    var elemTicket = window.document.getElementsByTagName('cas:proxyTicket')[0];
-                    if (elemTicket) {
-                        var proxyTicket = elemTicket.textContent;
-                        callback(undefined, proxyTicket);
-                        return;
-                    }
-                    // Got a proxy failure
-                    var elemFailure = window.document.getElementsByTagName('cas:proxyFailure')[0];
-                    if (elemFailure) {
-                        var code = elemFailure.getAttribute('code');
-                        var message = 'Proxy failure [' + code + ']: ';
-                        message += elemFailure.textContent;
-                        callback(new Error(message));
-                        return;
-                    }
-                    // Unexpected response
-                    callback(new Error("Bad response format: " + response));
+                // Use cheerio to parse the XML response
+                var $ = cheerio.load(response);
+                
+                // Got the proxy ticket
+                var elemTicket = $('cas\\:proxyTicket').first();
+                if (elemTicket && elemTicket.length > 0) {
+                    var proxyTicket = elemTicket.text();
+                    callback(undefined, proxyTicket);
                     return;
-                });
+                }
+                // Got a proxy failure
+                var elemFailure = $('cas\\:proxyFailure').first();
+                if (elemFailure && elemFailure.length > 0) {
+                    var code = elemFailure.attr('code');
+                    var message = 'Proxy failure [' + code + ']: ';
+                    message += elemFailure.text();
+                    callback(new Error(message));
+                    return;
+                }
+                // Unexpected response
+                callback(new Error("Bad response format: " + response));
+                return;
             });
         });
 
@@ -1014,8 +1002,8 @@ CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callb
 var parseAttributes = function(elemSuccess) 
 {
     var attributes = {};
-    var elemAttribute = elemSuccess.getElementsByTagName('cas:attributes')[0];
-    if (elemAttribute && elemAttribute.hasChildNodes()) {
+    var elemAttribute = elemSuccess.find('cas\\:attributes').first();
+    if (elemAttribute && elemAttribute.children().length > 0) {
         // "Jasig Style" Attributes:
         // 
         //  <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
@@ -1032,11 +1020,11 @@ var parseAttributes = function(elemSuccess)
         //      </cas:authenticationSuccess>
         //  </cas:serviceResponse>
         //
-        for (var i=0; i<elemAttribute.childNodes.length; i++) {
-            var node = elemAttribute.childNodes[i];
-            var attrName = node.nodeName.toLowerCase().replace(/cas:/, '');
+        for (var i=0; i<elemAttribute.children().length; i++) {
+            var node = elemAttribute.children()[i];
+            var attrName = node.name.toLowerCase().replace(/cas:/, '');
             if (attrName != '#text') {
-                var attrValue = node.textContent;
+                var attrValue = cheerio(node).text();
                 if (!attributes[attrName]) {
                     attributes[attrName] = [attrValue];
                 } else {
@@ -1063,9 +1051,9 @@ var parseAttributes = function(elemSuccess)
         //        </cas:authenticationSuccess>
         //    </cas:serviceResponse>
         // 
-        for (var i=0; i<elemSuccess.childNodes.length; i++) {
-            var node = elemSuccess.childNodes[i];
-            var tagName = node.nodeName.toLowerCase().replace(/cas:/, '');
+        for (var i=0; i<elemSuccess.children().length; i++) {
+            var node = elemSuccess.children()[i];
+            var tagName = node.name.toLowerCase().replace(/cas:/, '');
             switch (tagName) {
                 case 'user':
                 case 'proxies':
@@ -1075,7 +1063,7 @@ var parseAttributes = function(elemSuccess)
                     break;
                 default:
                     var attrName = tagName;
-                    var attrValue = node.textContent;
+                    var attrValue = cheerio(node).text();
                     if (attrValue != '') {
                         if (!attributes[attrName]) {
                             attributes[attrName] = [attrValue];
@@ -1109,11 +1097,11 @@ var parseAttributes = function(elemSuccess)
         //        </cas:authenticationSuccess>
         //    </cas:serviceResponse>
         //
-        var nodes = elemSuccess.getElementsByTagName('cas:attribute');
+        var nodes = elemSuccess.find('cas\\:attribute');
         if (nodes && nodes.length) {
             for (var i=0; i<nodes.length; i++) {
-                var attrName = nodes[i].getAttribute('name');
-                var attrValue = nodes[i].getAttribute('value');
+                var attrName = nodes[i].attr('name');
+                var attrValue = nodes[i].attr('value');
                 if (!attributes[attrName]) {
                     attributes[attrName] = [attrValue];
                 } else {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -105,6 +105,7 @@ var CAS = module.exports = function CAS(options)
   this.base_path = cas_url.pathname;
   this.service = options.service;
   this.pgtStore = {};
+  this.pgt_is_external = false;
   
   // Optional single sign out server list
   if (options.sso_servers) {
@@ -120,6 +121,7 @@ var CAS = module.exports = function CAS(options)
     if (!pgt_url.hostname) {
       throw new Error('Option `external_pgt_url` must be a valid url like: https://example.com:8989/callback');
     }
+    this.is_pgt_external = true;
     this.pgt_url = url.format(pgt_url);
     
     // A PGT callback URL is only useful if you also have a proxy URL to 
@@ -497,6 +499,54 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
 
 
 /**
+ * Fetches the PGT value that matches a given PGTIOU.
+ * Used internally by getProxyTicket().
+ *
+ * @param {String} pgtIOU
+ *     This is the PGTIOU that can be found in the validation response of the
+ *     CAS server.
+ * @param {Function} callback
+ *     callback(err, pgt)
+ * @return {null|String}
+ *     If using an internal PGT callback server, then the PGT will also
+ *     be delivered as the return value. Otherwise, NULL.
+ */
+CAS.prototype.getProxyGrantingTicket = function(pgtIOU, callback)
+{
+    var pgt = '';
+    
+    // If configured for external proxy server use, fetch the PT from there
+    if (this.is_pgt_external) {
+        var urlFetchPGT = url.parse(this.pgt_url + 'getPGT?pgtiou=' + pgtIOU);
+        https.get(urlFetchPGT, function(res) {
+            res.on('data', function(chunk) {
+                pgt += chunk;
+            });
+            res.on('end', function() {
+                callback(null, pgt);
+            });
+            res.on('error', function(err) {
+                callback(err);
+            });
+        });
+        return null;
+    }
+
+    // Look up the PGT locally
+    else if (this.pgtStore[pgtIOU]) {
+        pgt = this.pgtStore[pgtIOU]['pgtID'];
+        callback && callback(null, pgt);
+        return pgt;
+    }
+    else {
+        callback && callback(new Error('Invalid PGTIOU supplied'));
+        return null;
+    }
+}
+
+
+
+/**
  * Obtain a Proxy Ticket (PT) that can be used to access a service on behalf
  * of a user.
  *
@@ -510,64 +560,68 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
  */
 CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback) 
 {
-    // Look up the PGT using the PGTIOU
-    if (!this.pgtStore[pgtIOU]) {
-        callback(new Error('Invalid PGTIOU supplied'));
-        return;
-    }
-    var pgt = this.pgtStore[pgtIOU]['pgtID'];
-
-    var req = https.get({
-        host: this.hostname,
-        port: this.port,
-        path: url.format({
-            'pathname': this.base_path + '/proxy',
-            'query': { 
-                'targetService': targetService,
-                'pgt': pgt
-            }
-        })
-    }, function(res) {
-        // Handle server errors
-        res.on('error', function(e) {
-            callback(e);
-        });
-        
-        // Read result
-        res.setEncoding('utf8');
-        var response = '';
-        res.on('data', function(chunk) {
-            response += chunk;
-            if (response.length > 1e6) {
-                req.connection.destroy();            
-            }
-        });
-        res.on('end', function() {
-            // Use jsdom to parse the XML response
-            jsdom.env(response, function(err, window) {
-                if (err) {
-                    callback(new Error("jsdom could not parse response: " + response));
-                    return;
+    var self = this;
+    
+    // Obtain the PGT
+    this.getProxyGrantingTicket(pgtIOU, function(err, pgt) {
+        if (err) {
+            callback(err);
+            return;
+        }
+        // Query the CAS server
+        var req = https.get({
+            protocol: 'https:',
+            hostname: self.hostname,
+            port: self.port,
+            path: url.format({
+                pathname: self.base_path + '/proxy',
+                query: { 
+                    'targetService': targetService,
+                    'pgt': pgt
                 }
-                // Got the proxy ticket
-                var elemTicket = window.document.getElementsByTagName('cas:proxyTicket')[0];
-                if (elemTicket) {
-                    var proxyTicket = elemTicket.textContent;
-                    callback(undefined, proxyTicket);
-                    return;
+            })
+        }, function(res) {
+            // Handle server errors
+            res.on('error', function(e) {
+                callback(e);
+            });
+            
+            // Read result
+            res.setEncoding('utf8');
+            var response = '';
+            res.on('data', function(chunk) {
+                response += chunk;
+                if (response.length > 1e6) {
+                    req.connection.destroy();            
                 }
-                // Got a proxy failure
-                var elemFailure = window.document.getElementsByTagName('cas:proxyFailure')[0];
-                if (elemFailure) {
-                    var code = elemFailure.getAttribute('code');
-                    var message = 'Proxy failure [' + code + ']: ';
-                    message += elemFailure.textContent;
-                    callback(new Error(message));
+            });
+            res.on('end', function() {
+                // Use jsdom to parse the XML response
+                jsdom.env(response, function(err, window) {
+                    if (err) {
+                        callback(new Error("jsdom could not parse response: " + response));
+                        return;
+                    }
+                    // Got the proxy ticket
+                    var elemTicket = window.document.getElementsByTagName('cas:proxyTicket')[0];
+                    if (elemTicket) {
+                        var proxyTicket = elemTicket.textContent;
+                        callback(undefined, proxyTicket);
+                        return;
+                    }
+                    // Got a proxy failure
+                    var elemFailure = window.document.getElementsByTagName('cas:proxyFailure')[0];
+                    if (elemFailure) {
+                        var code = elemFailure.getAttribute('code');
+                        var message = 'Proxy failure [' + code + ']: ';
+                        message += elemFailure.textContent;
+                        callback(new Error(message));
+                        return;
+                    }
+                    // Unexpected response
+                    callback(new Error("Bad response format: " + response));
                     return;
-                }
-                // Unexpected response
-                callback(new Error("Bad response format: " + response));
-                return;
+                });
             });
         });
     });
@@ -614,7 +668,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     var self = this;
     
     // This is the pgtURL that will be sent to the CAS server during a
-    // validation request. The CAS server will try to conntect to it.
+    // validation request. The CAS server will try to connect to it.
     this.pgt_url = 'https://' + callbackHost + ':' + callbackPort + '/';
     
     // PGT callback server that listens for incoming connections from
@@ -622,24 +676,47 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
     var pgtServer = https.createServer(serverOptions);
     console.log('Starting PGT callback server on port ' + callbackPort);
     pgtServer.addListener("request", function(req, res) {
+        
+        var reqURL = url.parse(req.url, true);
+
+        // Check if this is a request from a CAS _client_ to get a PGT.
+        // [ see first part of getProxyTicket() ]
+        if (reqURL.pathname == '/getPGT') {
+            var pgtIOU = reqURL.query['pgtiou'];
+            if (self.pgtStore[pgtIOU]) {
+                res.writeHead(200, { 'Content-type': 'text/plain' });
+                res.write(self.pgtStore[pgtIOU]['pgtID']);
+                res.end();
+            }
+            else {
+                res.writeHead(403, { 'Content-type': 'text/plain' });
+                res.write("Invalid PGTIOU supplied");
+                res.end();
+            }
+            return;
+        }
+    
+        // Otherwise this is a connection from the CAS _server_.
         // The incoming connection tells us what the PGTIOU and PGT values
         // are. It expects only a HTTP 200 response in return.
-        res.writeHead(200, {'Content-Type': 'text/plain'});
-        res.end();
-        // Save the PGT ticket into the memory store
-        var reqURL = url.parse(req.url, true);
-        var pgtIOU = reqURL.query['pgtIou'];
-        var pgtID = reqURL.query['pgtId'];
-        if (pgtIOU && pgtID) {
-            self.pgtStore[ pgtIOU ] = {
-                'pgtID': pgtID,
-                'time': process.uptime()
-            };
+        else {
+            res.writeHead(200, {'Content-Type': 'text/plain'});
+            res.end();
+            // Save the PGT ticket into the memory store
+            var pgtIOU = reqURL.query['pgtIou'];
+            var pgtID = reqURL.query['pgtId'];
+            if (pgtIOU && pgtID) {
+                self.pgtStore[ pgtIOU ] = {
+                    'pgtID': pgtID,
+                    'time': process.uptime()
+                };
+            }
+            return;
         }
     });
     pgtServer.listen(callbackPort);
     
-    // Start an interval for PGT garbage collection.
+    // Start an interval for garbage collection of the local PGT store.
     if (this.pgtInterval) {
         clearInterval(this.pgtInterval);
     }
@@ -654,8 +731,8 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
         }
     }, 1000 * 60);
     
-    // Proxy server that listens for local connections and forwards them to 
-    // the target service. Disabled by default.
+    // Proxy server that listens for HTTPS connections from other CAS clients
+    // and forwards them to the target service. Disabled by default.
     if (proxyPort) {
         var proxyServer = https.createServer(serverOptions);
         console.log('Starting CAS proxy server on port ' + proxyPort);

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -497,16 +497,26 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
 
 
 /**
- * Send a PGT to the CAS server, and get a PT in return.
- * Used internally by the proxy server.
+ * Obtain a Proxy Ticket (PT) that can be used to access a service on behalf
+ * of a user.
  *
- * @param {string} pgt
- *      Proxy granting ticket
+ * Used internally by proxiedRequest(), but you may also use it to manually
+ * assemble proxied requests by other means.
+ *
+ * @param {string} pgtIOU
+ *      The PGTIOU that was given by the CAS server when the user logged in.
  * @param {function} callback
  *      callback(err, pt)
  */
-CAS.prototype.getProxyTicket = function(pgt, targetService, callback) 
+CAS.prototype.getProxyTicket = function(pgtIOU, targetService, callback) 
 {
+    // Look up the PGT using the PGTIOU
+    if (!this.pgtStore[pgtIOU]) {
+        callback(new Error('Invalid PGTIOU supplied'));
+        return;
+    }
+    var pgt = this.pgtStore[pgtIOU]['pgtID'];
+
     var req = https.get({
         host: this.hostname,
         port: this.port,
@@ -664,7 +674,7 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
                 if (!targetURL) {
                     throw 'Header "cas-proxy-targeturl" was not found';
                 }
-                targetOptions = url.parse(targetURL, true);
+                var targetOptions = url.parse(targetURL, true);
                 if (!targetOptions.hostname) {
                     throw 'Invalid "cas-proxy-targeturl" was given';
                 }
@@ -738,16 +748,9 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
         return;
     }
 
-    // Look up the PGT using the PGTIOU
-    if (!this.pgtStore[pgtIOU]) {
-        callback(new Error('Invalid PGTIOU supplied'));
-        return;
-    }
-    var pgt = this.pgtStore[pgtIOU]['pgtID'];
-    
     var targetService = url.format(options);
     
-    this.getProxyTicket(pgt, targetService, function(err, pt) {
+    this.getProxyTicket(pgtIOU, targetService, function(err, pt) {
         if (err) {
             callback(err);
             return;

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -365,6 +365,7 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
   // Use different CAS path depending on version
   var validate_path;
   var pgtURL;
+  var cas_version = this.version;
   if (this.version < 2.0) {
     // CAS 1.0
     validate_path = 'validate';
@@ -426,7 +427,7 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
 
     res.on('end', function() {
       // CAS 1.0
-      if (this.version < 2.0) {
+      if (cas_version < 2.0) {
         var sections = response.split('\n');
         if (sections.length >= 1) {
           if (sections[0] == 'no') {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -40,11 +40,11 @@ var jsdom = require('jsdom');
  *
  *       'proxy_server': 
  *           (optional) Set to TRUE if you want to automatically start 
- *           a proxy callback server locally.
+ *           a proxy callback server internally.
  *           Do not use with `external_pgt_url`.
  *       'proxy_server_port':
- *           (optional) The port to listen on for outgoing requests that are
- *           to be forwarded to an external CAS enabled service.
+ *           (optional) The port to listen on for external proxy requests for 
+ *           a CAS enabled service.
  *           Disabled by default.
  *       'proxy_callback_host':
  *           The publicly accessible host name of your callback server.
@@ -376,8 +376,8 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
                     var thisProxy = elemProxies[i].textContent;
                     // trim whitespace
                     thisProxy = thisProxy
-                        .replace(/^\s+/, '', thisProxy)
-                        .replace(/\s+$/, '', thisProxy);
+                        .replace(/^\s+/, '')
+                        .replace(/\s+$/, '');
                     proxies.push(thisProxy);
                 }
 
@@ -673,12 +673,30 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
             serviceObj = http;
         }
         try {
-            var req = serviceObj.get(options, function(res) {
-                callback(undefined, req, res);
-            });
+            switch (options.method.toUpperCase()) {
+                default:
+                case 'GET':
+                case 'HEADER':
+                    // get() automatically ends the request.
+                    var req = serviceObj.get(options, function(res) {
+                        callback(undefined, req, res);
+                    });
+                    break;
+                    
+                case 'POST':
+                case 'PUT':
+                    // Let the calling function end the request manually after
+                    // it has finished sending all its data.
+                    var res;
+                    var req = serviceObj.request(options, function(_res) {
+                        res = _res;
+                    });
+                    callback(undefined, req, res);
+                    break;
+            }
         }
-        catch (e) {
-            callback(e);
+        catch (err) {
+            callback(err);
         }
         
     });
@@ -701,10 +719,6 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
  */
 CAS.prototype.proxiedRequestExternal = function(proxyURL, pgtIOU, options, callback) 
 {
-    if (!this.external_proxy_url) {
-        throw new Error('Option `external_proxy_url` is required in order to use proxiedRequestExternal()');
-    }
-    
     var targetService = url.format(options);
     var proxyInfo = url.parse(proxyURL);
 

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -59,6 +59,11 @@ var jsdom = require('jsdom');
  *       'proxy_server_cert':
  *           A string value of your SSL certificate. 
  *           Required only if you used `proxy_server`.
+ *
+ *       'sso_servers':
+ *           An array of IP addresses of servers that are allowed to make
+ *           single sign out requests. Default is to accept all valid requests.
+ *           Only relevant if you use handleSignleSignout().
  *     }
  * @api public
  */
@@ -90,6 +95,11 @@ var CAS = module.exports = function CAS(options)
   this.base_path = cas_url.pathname;
   this.service = options.service;
   this.pgtStore = {};
+  
+  // Optional single sign out server list
+  if (options.sso_servers) {
+    this.ssoServers = options.sso_servers;
+  }
 
   // User has supplied an external PGT callback URL
   if (options.external_pgt_url) {
@@ -107,7 +117,7 @@ var CAS = module.exports = function CAS(options)
     if (options.external_proxy_url) {
       var proxy_url = url.parse(options.external_proxy_url);
       if (!proxy_url.hostname) {
-        throw new Error('Option `external_proxy_url` must be a vald url like: https://example.com:8080');
+        throw new Error('Option `external_proxy_url` must be a vald url like: https://example.com:8080/');
       }
       this.external_proxy_url = url.format(proxy_url);
     }
@@ -180,7 +190,6 @@ CAS.prototype.authenticate = function(req, res, callback, service)
             pathname: reqURL.pathname,
             query: reqURL.query
         });
-        //console.log('authenticate() -- derived service: ' + service);
     }
     
     // No ticket, so we haven't been sent to the CAS server yet
@@ -229,6 +238,12 @@ CAS.prototype.authenticate = function(req, res, callback, service)
 CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
 {
     if (req.method == 'POST' && req.body['logoutRequest']) {
+        // Check IP address
+        var remoteIP = req.connection.remoteAddress;
+        if (this.ssoServers && this.ssoServers.indexOf(remoteIP) < 0) {
+            // not a recognized single signout server
+            return next();
+        }
         // This was a signout request. Parse the XML.
         jsdom.env(req.body['logoutRequest'], function(err, window) {
             if (!err) {
@@ -236,21 +251,20 @@ CAS.prototype.handleSingleSignout = function(req, res, next, logoutCallback)
                 if (ticketElem) {
                     // This is the ticket that was issued by CAS when the user
                     // first logged in. Pass it into the callback so the
-                    // framework can delete the user's session based on that.
+                    // framework can use it to delete the user's session.
                     var ticket = ticketElem.textContent
                         .replace(/^\s+/, '')
                         .replace(/\s+$/, '');
-                    logoutCallback(ticket);
-                    return;
+                    return logoutCallback(ticket);
                 }
             }
             // This was not a valid signout request.
-            next();
+            return next();
         });
     }
     else {
         // This was not a signout request. Proceed normally.
-        next();
+        return next();
     }
 }
 
@@ -357,7 +371,6 @@ CAS.prototype.validate = function(ticket, callback, service, renew)
       pathname: this.base_path+'/'+validate_path,
       query: query
     });
-  //console.log('CAS validate path: ' + queryPath);
 
   var req = https.get({
     host: this.hostname,
@@ -599,9 +612,6 @@ CAS.prototype.startProxyServer = function(key, cert, callbackHost, callbackPort,
         var pgtID = reqURL.query['pgtId'];
         if (pgtIOU && pgtID) {
             self.pgtStore[ pgtIOU ] = pgtID;
-            //console.log('Callback -- got PGT: ' + pgtID);
-        } else {
-            //console.error('Callback -- Got unrecognized request: ' + req.method + ' ' + req.url);
         }
     });
     pgtServer.listen(callbackPort);
@@ -706,7 +716,6 @@ CAS.prototype.proxiedRequest = function(pgtIOU, options, callback)
     }
     
     var targetService = url.format(options);
-    //console.log('Proxied Request -- targetService: ' + targetService);
     
     this.getProxyTicket(pgt, targetService, function(err, pt) {
         if (err) {

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -686,11 +686,13 @@ var parseAttributes = function(elemSuccess) {
         for (var i=0; i<elemAttribute.childNodes.length; i++) {
             var node = elemAttribute.childNodes[i];
             var attrName = node.nodeName.toLowerCase().replace(/cas:/, '');
-            var attrValue = node.textContent;
-            if (!attributes[attrName]) {
-                attributes[attrName] = [attrValue];
-            } else {
-                attributes[attrName].push(attrValue);
+            if (attrName != '#text') {
+                var attrValue = node.textContent;
+                if (!attributes[attrName]) {
+                    attributes[attrName] = [attrValue];
+                } else {
+                    attributes[attrName].push(attrValue);
+                }
             }
         }
     }
@@ -719,6 +721,7 @@ var parseAttributes = function(elemSuccess) {
                 case 'user':
                 case 'proxies':
                 case 'proxygrantingticket':
+                case '#text':
                     // these are not CAS attributes
                     break;
                 default:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     { "name": "Joshua Chan", "email": "other.joshua@gmail.com" }
   ],
   "dependencies": {
-    "jsdom": "= 3.1.x"
+    "jsdom": "3.1.x"
   },
   "main": "index",
   "engines": { "node": "0.4 || 0.5 || 0.6" }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,31 @@
   "name": "cas",
   "version": "0.0.5",
   "description": "Central Authentication Service (CAS) client for Node.js",
-  "keywords": ["cas", "central authentication service", "auth", "authentication", "central", "service"],
+  "keywords": [
+    "cas",
+    "central authentication service",
+    "auth",
+    "authentication",
+    "central",
+    "service"
+  ],
   "author": "Casey Banner <kcbanner@gmail.com>",
   "contributors": [
-    { "name": "Joshua Chan", "email": "joshua@appdevdesigns.net" }
+    {
+      "name": "Joshua Chan",
+      "email": "joshua@appdevdesigns.net"
+    }
   ],
   "dependencies": {
-    "jsdom": "3.1.x"
+    "cheerio": "0.19.0"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "nock": "^7.0.2",
+    "should": "^8.2.1"
+  },
+  "scripts": {
+    "test": "make test"
   },
   "main": "index"
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "cas",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Central Authentication Service (CAS) client for Node.js",
   "keywords": ["cas", "central authentication service", "auth", "authentication", "central", "service"],
   "author": "Casey Banner <kcbanner@gmail.com>",
   "contributors": [
-    { "name": "Joshua Chan", "email": "other.joshua@gmail.com" }
+    { "name": "Joshua Chan", "email": "joshua@appdevdesigns.net" }
   ],
   "dependencies": {
     "jsdom": "3.1.x"
   },
-  "main": "index",
-  "engines": { "node": "0.4 || 0.5 || 0.6" }
+  "main": "index"
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "cas",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Central Authentication Service (CAS) client for Node.js",
   "keywords": ["cas", "central authentication service", "auth", "authentication", "central", "service"],
   "author": "Casey Banner <kcbanner@gmail.com>",
-  "dependencies": {},
+  "contributors": [
+    { "name": "Joshua Chan", "email": "other.joshua@gmail.com" }
+  ],
+  "dependencies": {
+    "jsdom": ">= 0.2.10"
+  },
   "main": "index",
   "engines": { "node": "0.4 || 0.5 || 0.6" }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     { "name": "Joshua Chan", "email": "other.joshua@gmail.com" }
   ],
   "dependencies": {
-    "jsdom": ">= 0.2.10"
+    "jsdom": "= 3.1.x"
   },
   "main": "index",
   "engines": { "node": "0.4 || 0.5 || 0.6" }

--- a/test/node-cas.test.js
+++ b/test/node-cas.test.js
@@ -3,11 +3,310 @@
  * Module dependencies.
  */
 
-var cas = require('node-cas')
-  , should = require('should');
+var CAS = require('../lib/cas')
+    , should = require('should')
+    , nock = require('nock');
+
+// Initial server infomation
+var base_url = 'https://localhost/cas',
+    service = 'test_service',
+    sso_servers = ['test_remote_address'],
+    cas = new CAS({
+        base_url: base_url,
+        service: service,
+        version: 2.0,
+        sso_servers: sso_servers
+    });
 
 module.exports = {
-  'test .version': function(){
-    cas.version.should.match(/^\d+\.\d+\.\d+$/);
-  }
+    'test .version': function () {
+        CAS.version.should.match(/^\d+\.\d+\.\d+$/);
+    },
+
+
+    'handleSingleSignout - should return valid ticket in callback': function () {
+        // Assign
+        var ticket = 'TICKET';
+
+        var req = {
+            method: 'POST',
+            body: {
+                logoutRequest: '<samlp:LogoutRequest>' + 
+                                    '<samlp:SessionIndex>' + 
+                                        ticket + 
+                                    '</samlp:SessionIndex>' +
+                               '</samlp:LogoutRequest>'
+            },
+            connection: {
+                remoteAddress: sso_servers[0]
+            }
+        };
+        var res = {};
+        var next = function () {
+            // Assert
+            should.not.exist(true, 'should not call this function');
+        };
+        var logoutCallback = function (result) {
+            // Assert
+            should.equal(result, ticket, 'should return valid ticket');
+        };
+
+        // Action
+        cas.handleSingleSignout(req, res, next, logoutCallback);
+    },
+
+
+    'handleSingleSignout - should call next method when get invalid request': function() {
+        // Assign
+        var req = {
+            method: 'POST',
+            body: {
+                logoutRequest: 'INVALID REQUEST'
+            },
+            connection: {
+                remoteAddress: sso_servers[0]
+            }
+        };
+        var res = {};
+        var next = function () {
+            // Assert
+            should.exist(true, 'should call this function');
+        };
+        var logoutCallback = function (result) {
+            // Assert
+            should.not.exist(result, 'should not return any tickets');
+        };
+
+        // Action
+        cas.handleSingleSignout(req, res, next, logoutCallback);
+    },
+
+
+    'validate - should return valid ticket information': function () {
+        // Assign
+        var ticket = "TEST TICKET";
+        var user = "TEST USERNAME";
+        var attributes = {
+            attrastyle: ['RubyCAS'],
+            surname: ['Smith'],
+            givenname: ['John'],
+            memberof: ['CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,...']
+        };
+        var attributesTag = '<cas:attributes>' +
+                                '<cas:attraStyle>' + attributes.attrastyle[0] + '</cas:attraStyle>' +
+                                '<cas:surname>' + attributes.surname[0] + '</cas:surname>' +
+                                '<cas:givenName>' + attributes.givenname[0] + '</cas:givenName>' +
+                                '<cas:memberOf>' + attributes.memberof[0] + '</cas:memberOf>' +
+                                '<cas:memberOf>' + attributes.memberof[1] + '</cas:memberOf>' +
+                            '</cas:attributes>';
+        var proxyGrantingTicket = "PROXY_GRANTING_TICKET";
+        var proxies = ['proxy1', 'proxy2'];
+        var proxiesTag = '';
+        proxies.forEach(function (proxy) {
+            proxiesTag += '<cas:proxies>' + proxy + '</cas:proxies>';
+        });
+
+        // Mock up response 
+        nock(base_url)
+            .get('/proxyValidate')
+            .query({ ticket: ticket, service: service })
+            .reply(200,
+                '<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">' +
+                    '<cas:authenticationSuccess>' +
+                        '<cas:user>' + user + '</cas:user>' +
+                        attributesTag +
+                        '<cas:proxyGrantingTicket>' + proxyGrantingTicket + '</cas:proxyGrantingTicket>' +
+                        proxiesTag +
+                    '</cas:authenticationSuccess>' +
+                '</cas:serviceResponse>');
+
+        var callback = function (err, one, username, ticketInfo) {
+            // Assert
+            should.not.exist(err, 'should not have any errors');
+
+            one.should.equal(true);
+
+            should.exist(username, 'should have username');
+            should.equal(username, user, 'should return valid username');
+
+            should.exist(ticketInfo, 'should have ticketInfo');
+
+            should.exist(ticketInfo.username, 'should have username property');
+            should.equal(ticketInfo.username, user, 'should have username');
+
+            should.exist(ticketInfo.attributes, 'should have attributes property');
+            should.deepEqual(ticketInfo.attributes, attributes, 'should have attributes');
+
+            should.exist(ticketInfo.PGTIOU, 'should have PGTIOU property');
+            should.equal(ticketInfo.PGTIOU, proxyGrantingTicket, 'should have PGTIOU property');
+
+            should.exist(ticketInfo.ticket, 'should have ticket property');
+            should.equal(ticketInfo.ticket, ticket, 'should return valid ticket property');
+
+            should.exist(ticketInfo.proxies, 'should have proxies property');
+            should.deepEqual(ticketInfo.proxies, proxies, 'should return valid proxies');
+        };
+
+        // Action
+        cas.validate(ticket, callback, service, null);
+    },
+
+
+    'validate - should return error when server does not return user info': function () {
+        // Assign
+        var ticket = "TEST TICKET";
+
+         // Mock up response 
+        nock(base_url)
+            .get('/proxyValidate')
+            .query({ ticket: ticket, service: service })
+            .reply(200,
+                '<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">' +
+                    '<cas:authenticationSuccess>' +
+                        '<cas:proxyGrantingTicket>TEST PROXY GRANTING TICKET</cas:proxyGrantingTicket>' +
+                    '</cas:authenticationSuccess>' +
+                '</cas:serviceResponse>');
+
+         var callback = function (err, one, username, ticketInfo) {
+            // Assert
+            should.exist(err, 'should return a error');
+            should.equal(err.message, 'No username?', 'should return no username error message');
+            
+            should.exist(one, 'should return');
+            should.equal(one, false, 'should return false');
+            
+            should.not.exist(username, 'should not return username');
+            should.not.exist(ticketInfo, 'should not return ticket info');
+         };
+
+        // Action
+        cas.validate(ticket, callback, service, null);
+    },
+
+
+    'validate - should return error when server does not return invalid info': function () {
+        // Assign
+        var ticket = "TEST TICKET";
+
+         // Mock up response 
+        nock(base_url)
+            .get('/proxyValidate')
+            .query({ ticket: ticket, service: service })
+            .reply(200, 'INVALID RESPONSE DATA');
+
+         var callback = function (err, one, username, ticketInfo) {
+            // Assert
+            should.exist(err, 'should return a error');
+            should.equal(err.message, 'Bad response format.', 'should return bad request error message');
+            
+            should.not.exist(one, 'should not return');
+            should.not.exist(username, 'should not return username');
+            should.not.exist(ticketInfo, 'should not return ticket info');
+         };
+
+        // Action
+        cas.validate(ticket, callback, service, null);
+    },
+
+
+    'getProxyTicket - should return valid proxy ticket': function () {
+        // Assign
+        var proxyTicket = 'TEST proxyTicket';
+        var pgtID = 'TEST pgtID';
+        var pgtIOU = 'TEST pgtIOU';
+
+        cas.pgtStore[pgtIOU] = {
+            'pgtID': pgtID,
+            'time': process.uptime()
+        };
+
+        // Mock up response 
+        nock(base_url)
+            .get('/proxy')
+            .query({ targetService: service, pgt: pgtID })
+            .reply(200, '<cas:serviceResponse>' +
+                            '<cas:proxySuccess>' +
+                                '<cas:proxyTicket>' + proxyTicket + '</cas:proxyTicket>' +
+                            '</cas:proxySuccess>' +
+                        '</cas:serviceResponse>');
+
+        var callback = function (err, returnProxyTicket) {
+            // Assert
+            should.not.exist(err, 'should not have any errors');
+
+            should.exist(returnProxyTicket, 'should have proxy ticket');
+            should.equal(returnProxyTicket, proxyTicket, 'should return valid proxy ticket');
+        };
+
+        // Action
+        cas.getProxyTicket(pgtIOU, service, callback);
+    },
+    
+    'getProxyTicket - should return proxy failure error': function () {
+        // Assign
+        var pgtID = 'TEST pgtID';
+        var pgtIOU = 'TEST pgtIOU';
+
+        cas.pgtStore[pgtIOU] = {
+            'pgtID': pgtID,
+            'time': process.uptime()
+        };
+
+        var errorCode = 500;
+        var errorMessage = 'TEST Error message';
+
+        // Mock up response
+        nock(base_url)
+            .get('/proxy')
+            .query({ targetService: service, pgt: pgtID })
+            .reply(200, '<cas:serviceResponse>' +
+                            '<cas:proxyFailure code="' + errorCode + '">' +
+                                errorMessage +
+                            '</cas:proxyFailure>' +
+                        '</cas:serviceResponse>');
+                        
+        var callback = function(err, returnProxyTicket) {
+            // Assert
+            should.exist(err, 'should have a error');
+            should.equal(err.message, 'Proxy failure [' + errorCode + ']: ' + errorMessage, 'should return valid error message');
+            
+            should.not.exist(returnProxyTicket, 'should not return any tickets');
+        };
+
+        // Action
+        cas.getProxyTicket(pgtIOU, service, callback);
+    },
+    
+    
+    'getProxyTicket - should return bad request when server return invalid data': function() {
+        // Assign
+        var pgtID = 'TEST pgtID';
+        var pgtIOU = 'TEST pgtIOU';
+
+        cas.pgtStore[pgtIOU] = {
+            'pgtID': pgtID,
+            'time': process.uptime()
+        };
+
+        var invalidResponse = 'INVALID RESPONSE DATA';
+
+        // Mock up response
+        nock(base_url)
+            .get('/proxy')
+            .query({ targetService: service, pgt: pgtID })
+            .reply(200, invalidResponse);
+                        
+        var callback = function(err, returnProxyTicket) {
+            // Assert
+            should.exist(err, 'should have a error');
+            console.log(err.message);
+            should.equal(err.message, "Bad response format: " + invalidResponse, 'should return bad request error message');
+            
+            should.not.exist(returnProxyTicket, 'should not return any tickets');
+        };
+
+        // Action
+        cas.getProxyTicket(pgtIOU, service, callback);
+    }
+
 };


### PR DESCRIPTION
Okay, I think I'm finally done. Hoping to see this packaged into npm if all goes well.

The module should be backwards compatible. All the new functions can be ignored if you only need to use validate() manually. It will still use the CAS 1.0 protocol by default unless 2.0 is specified. The only issue is I used `jsdom` to parse the XML. And that has one dependency (`contextify`) that is tricky to get working on Windows.
