### PR TITLE
Use 'hostname' instead of 'host', which includes port number.

### DIFF
--- a/lib/cas.js
+++ b/lib/cas.js
@@ -41,6 +41,7 @@ var CAS = module.exports = function CAS(options) {
   }  
   
   this.service = options.service;
+  this.https_options = options.https;
 };
 
 /**
@@ -59,14 +60,20 @@ CAS.version = '0.0.1';
  */
 
 CAS.prototype.validate = function(ticket, callback) {
-  var req = https.get({
+  var options = {
     host: this.hostname,
     port: this.port,
     path: url.format({
       pathname: this.base_path+'/validate',
       query: {ticket: ticket, service: this.service}
     })
-  }, function(res) {
+  };
+  for (var opt in this.https_options) {
+    if (this.https_options.hasOwnProperty(opt)) {
+      options[opt] = this.https_options[opt];
+    }
+  }
+  var req = https.get(options, function(res) {
     // Handle server errors
     res.on('error', function(e) {
       callback(e);

--- a/lib/cas.js
+++ b/lib/cas.js
@@ -35,7 +35,7 @@ var CAS = module.exports = function CAS(options) {
   } else if (!cas_url.hostname) {
     throw new Error('Option `base_url` must be a valid url like: https://example.com/cas');    
   } else {
-    this.hostname = cas_url.host;
+    this.hostname = cas_url.hostname;
     this.port = cas_url.port || 443;
     this.base_path = cas_url.pathname;
   }  

--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
   "author": "Casey Banner <kcbanner@gmail.com>",
   "dependencies": {},
   "main": "index",
-  "engines": { "node": "0.4 || 0.5 || 0.6 || 0.8 || 0.10" }
+  "engines": { "node": "0.4 || 0.5 || 0.6 || 0.8 || 0.10" },
+  "files": [
+    "index.js",
+    "lib/cas.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
   "author": "Casey Banner <kcbanner@gmail.com>",
   "dependencies": {},
   "main": "index",
-  "engines": { "node": "0.4 || 0.5 || 0.6" }
+  "engines": { "node": "0.4 || 0.5 || 0.6 || 0.8" }
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
   "author": "Casey Banner <kcbanner@gmail.com>",
   "dependencies": {},
   "main": "index",
-  "engines": { "node": "0.4 || 0.5 || 0.6 || 0.8" }
+  "engines": { "node": "0.4 || 0.5 || 0.6 || 0.8 || 0.10" }
 }


### PR DESCRIPTION
`url.parse("http://foo.com:444/bar").hostname` returns `"foo.com:444"`,
which causes `validate` to make an invalid call to `https`.

This permits using a CAS running on a different port.
